### PR TITLE
Remove g_type_class_add_private() usage (fixes FTBFS with glib 2.58).

### DIFF
--- a/gxneur/src/tray_widget.c
+++ b/gxneur/src/tray_widget.c
@@ -82,7 +82,7 @@ static GdkFilterReturn gtk_tray_icon_manager_filter (GdkXEvent *xevent,
 						     gpointer   user_data);
 
 
-G_DEFINE_TYPE (GtkTrayIcon, gtk_tray_icon, GTK_TYPE_PLUG)
+G_DEFINE_TYPE_WITH_CODE (GtkTrayIcon, gtk_tray_icon, GTK_TYPE_PLUG, G_ADD_PRIVATE (GtkTrayIcon))
 
 static void
 gtk_tray_icon_class_init (GtkTrayIconClass *class)
@@ -107,8 +107,6 @@ gtk_tray_icon_class_init (GtkTrayIconClass *class)
 						      GTK_TYPE_ORIENTATION,
 						      GTK_ORIENTATION_HORIZONTAL,
 						      GTK_PARAM_READABLE));
-
-	g_type_class_add_private (class, sizeof (GtkTrayIconPrivate));
 }
 
 static void


### PR DESCRIPTION
Signed-off-by: Alexander GQ Gerasiov <gq@cs.msu.su>