### PR TITLE
Remove dead code

### DIFF
--- a/xneur/lib/lib/xneurlib.c
+++ b/xneur/lib/lib/xneurlib.c
@@ -113,7 +113,7 @@ struct _xneur_handle *xneur_handle_create (void)
 	struct _xneur_handle *handle = (struct _xneur_handle *) malloc(sizeof(struct _xneur_handle));;
 	if (handle == NULL)
 		return NULL;
-	
+
 	XkbDescPtr kbd_desc_ptr;
 
 	if (!(kbd_desc_ptr = XkbAllocKeyboard()))
@@ -121,7 +121,7 @@ struct _xneur_handle *xneur_handle_create (void)
 		free(handle);
 		return NULL;
 	}
-	
+
 	Display *display = XOpenDisplay(NULL);
 
 	/*char *names[XkbNumKbdGroups];
@@ -132,7 +132,7 @@ struct _xneur_handle *xneur_handle_create (void)
 		printf("%d) %c %s\n", i, i == g ? '*' : ' ', names[i]);
 	}
 	free_layout(names, gc);*/
-	
+
 	XkbGetNames(display, XkbAllNamesMask, kbd_desc_ptr);
 
 	if (kbd_desc_ptr->names == NULL)
@@ -159,7 +159,7 @@ struct _xneur_handle *xneur_handle_create (void)
 	}
 
 	Atom _XKB_RULES_NAMES = XInternAtom(display, "_XKB_RULES_NAMES", 1);
-	if (_XKB_RULES_NAMES == None) 
+	if (_XKB_RULES_NAMES == None)
 	{
 		XCloseDisplay(display);
 		XkbFreeKeyboard(kbd_desc_ptr, XkbAllComponentsMask, True);
@@ -174,7 +174,7 @@ struct _xneur_handle *xneur_handle_create (void)
     unsigned long bytes_after;
     unsigned char *prop;
     int status;
-	
+
     status = XGetWindowProperty(display, rw, _XKB_RULES_NAMES, 0, (10000+3)/4,
 				False, AnyPropertyType, &type,
 				&size, &nitems, &bytes_after,
@@ -186,7 +186,7 @@ struct _xneur_handle *xneur_handle_create (void)
 		free(handle);
 		return NULL;
 	}
-	
+
 	if (size == 32)
 		nbytes = sizeof(long);
 	else if (size == 16)
@@ -202,11 +202,11 @@ struct _xneur_handle *xneur_handle_create (void)
 		free(handle);
 		return NULL;
 	}
-	
+
 	int prop_count = 0;
 	char *prop_value = NULL;
     long length = nitems * nbytes;
-	while (length >= size/8) 
+	while (length >= size/8)
 	{
 		int prop_value_len = get_next_property_value(&prop, &length, size, &prop_value);
 		if (prop_value_len == 0)
@@ -233,14 +233,14 @@ struct _xneur_handle *xneur_handle_create (void)
 		free(handle);
 		return NULL;
 	}
-	//log_message(ERROR, "%s", 
+	//log_message(ERROR, "%s",
 	handle->languages = (struct _xneur_language *) malloc(sizeof(struct _xneur_language));
 	handle->total_languages = 0;
 
 	for (int group = 0; group < groups_count; group++)
 	{
 		Atom group_atom = kbd_desc_ptr->names->groups[group];
-			
+
 		if (group_atom == None)
 			continue;
 
@@ -279,7 +279,7 @@ struct _xneur_handle *xneur_handle_create (void)
 
 		//if (group_name != NULL)
 			//free(group_name);
-		
+
 		if (prop_value == NULL)
 			break;
 		function_end:;
@@ -287,7 +287,7 @@ struct _xneur_handle *xneur_handle_create (void)
 
 	XCloseDisplay(display);
 	XkbFreeKeyboard(kbd_desc_ptr, XkbAllComponentsMask, True);
-	
+
 	if (handle->total_languages == 0)
 	{
 		free(handle);
@@ -314,32 +314,14 @@ struct _xneur_handle *xneur_handle_create (void)
 		char *lang_dir = (char *) malloc(path_len * sizeof(char));
 		snprintf(lang_dir, path_len, "%s/%s", LANGUAGEDIR, handle->languages[lang].dir);
 
-		handle->languages[lang].dictionary = load_list(lang_dir, DICT_NAME, TRUE);		
-		if (handle->languages[lang].dictionary == NULL)
-		{
-			handle->languages[lang].dictionary->data_count = 0;
-		}
-		else	
-		{
-			handle->languages[lang].dictionary->rem(handle->languages[lang].dictionary, "(?i)^.$");
-		}
-		
-		handle->languages[lang].proto = load_list(lang_dir, PROTO_NAME, TRUE);
-		if (handle->languages[lang].proto == NULL)
-			handle->languages[lang].proto->data_count = 0;
-
-		handle->languages[lang].big_proto = load_list(lang_dir, BIG_PROTO_NAME, TRUE);
-		if (handle->languages[lang].big_proto == NULL)
-			handle->languages[lang].big_proto->data_count = 0;
-
-		handle->languages[lang].pattern = load_list(lang_dir, PATTERN_NAME, TRUE);
-		if (handle->languages[lang].pattern == NULL)
-			handle->languages[lang].pattern->data_count = 0;
-		
+		handle->languages[lang].dictionary = load_list(lang_dir, DICT_NAME, TRUE);
+		handle->languages[lang].dictionary->rem(handle->languages[lang].dictionary, "(?i)^.$");
+		handle->languages[lang].proto      = load_list(lang_dir, PROTO_NAME, TRUE);
+		handle->languages[lang].big_proto  = load_list(lang_dir, BIG_PROTO_NAME, TRUE);
+		handle->languages[lang].pattern    = load_list(lang_dir, PATTERN_NAME, TRUE);
 		handle->languages[lang].temp_dictionary = handle->languages[lang].dictionary->clone(handle->languages[lang].dictionary);
 
-		if (lang_dir != NULL)
-			free(lang_dir);
+		free(lang_dir);
 	}
 
 #ifdef WITH_ASPELL
@@ -445,21 +427,21 @@ struct _xneur_handle *xneur_handle_create (void)
 			);
 	}
 
-	return handle;	
+	return handle;
 }
 
 void xneur_handle_destroy (struct _xneur_handle *handle)
 {
-	if (handle == NULL) 
+	if (handle == NULL)
 		return;
-	
+
 	for (int lang = 0; lang < handle->total_languages; lang++)
 	{
 #ifdef WITH_ASPELL
 		if (handle->has_spell_checker[lang])
 			delete_aspell_speller(handle->spell_checkers[lang]);
 #endif
-		
+
 #ifdef WITH_ENCHANT
 		if ((handle->enchant_dicts[lang] != NULL) && (handle->has_enchant_checker[lang]))
 			enchant_broker_free_dict (handle->enchant_broker, handle->enchant_dicts[lang]);
@@ -467,7 +449,7 @@ void xneur_handle_destroy (struct _xneur_handle *handle)
 
 		if (handle->languages == NULL)
 			continue;
-		
+
 		if (handle->languages[lang].temp_dictionary != NULL)
 			handle->languages[lang].temp_dictionary->uninit(handle->languages[lang].temp_dictionary);
 
@@ -490,7 +472,7 @@ void xneur_handle_destroy (struct _xneur_handle *handle)
 	}
 	handle->total_languages = 0;
 	free(handle->languages);
-		
+
 #ifdef WITH_ASPELL
 	delete_aspell_config(handle->spell_config);
 	if (handle->spell_checkers != NULL)
@@ -498,7 +480,7 @@ void xneur_handle_destroy (struct _xneur_handle *handle)
 	if (handle->has_spell_checker != NULL)
 		free(handle->has_spell_checker);
 #endif
-	
+
 #ifdef WITH_ENCHANT
 	enchant_broker_free (handle->enchant_broker);
 	if (handle->enchant_dicts != NULL)
@@ -506,7 +488,7 @@ void xneur_handle_destroy (struct _xneur_handle *handle)
 	if (handle->has_enchant_checker != NULL)
 		free(handle->has_enchant_checker);
 #endif
-	
+
 	free(handle);
 
 }

--- a/xneur/lib/lib/xneurlib.c
+++ b/xneur/lib/lib/xneurlib.c
@@ -291,7 +291,6 @@ struct _xneur_handle *xneur_handle_create (void)
 		snprintf(lang_dir, path_len, "%s/%s", LANGUAGEDIR, handle->languages[lang].dir);
 
 		handle->languages[lang].dictionary = load_list(lang_dir, DICT_NAME, TRUE);
-		handle->languages[lang].dictionary->rem(handle->languages[lang].dictionary, "(?i)^.$");
 		handle->languages[lang].proto      = load_list(lang_dir, PROTO_NAME, TRUE);
 		handle->languages[lang].big_proto  = load_list(lang_dir, BIG_PROTO_NAME, TRUE);
 		handle->languages[lang].pattern    = load_list(lang_dir, PATTERN_NAME, TRUE);

--- a/xneur/lib/lib/xneurlib.c
+++ b/xneur/lib/lib/xneurlib.c
@@ -99,13 +99,13 @@ static const int names_len = sizeof(layout_names) / sizeof(layout_names[0]);
 
 static long get_next_property_value (unsigned char **pointer, long *length, int size, char **string)
 {
-    if (size != 8)
+	if (size != 8)
 		return 0;
 
-    int len = 0; *string = (char *)*pointer;
-    while ((len++, --*length, *((*pointer)++)) && *length>0);
+	int len = 0; *string = (char *)*pointer;
+	while ((len++, --*length, *((*pointer)++)) && *length>0);
 
-    return len;
+	return len;
 }
 
 struct _xneur_handle *xneur_handle_create (void)
@@ -168,14 +168,13 @@ struct _xneur_handle *xneur_handle_create (void)
 	}
 	Window rw = RootWindow(display, DefaultScreen(display));
 	Atom type;
-    int size;
-    unsigned long nitems;
-    unsigned long nbytes;
-    unsigned long bytes_after;
-    unsigned char *prop;
-    int status;
+	int size;
+	unsigned long nitems;
+	unsigned long bytes_after;
+	unsigned char *prop;
+	int status;
 
-    status = XGetWindowProperty(display, rw, _XKB_RULES_NAMES, 0, (10000+3)/4,
+	status = XGetWindowProperty(display, rw, _XKB_RULES_NAMES, 0, (10000+3)/4,
 				False, AnyPropertyType, &type,
 				&size, &nitems, &bytes_after,
 				&prop);
@@ -187,28 +186,11 @@ struct _xneur_handle *xneur_handle_create (void)
 		return NULL;
 	}
 
-	if (size == 32)
-		nbytes = sizeof(long);
-	else if (size == 16)
-		nbytes = sizeof(short);
-	else if (size == 8)
-		nbytes = 1;
-	else if (size == 0)
-		nbytes = 0;
-	else
-	{
-		XCloseDisplay(display);
-		XkbFreeKeyboard(kbd_desc_ptr, XkbAllComponentsMask, True);
-		free(handle);
-		return NULL;
-	}
-
 	int prop_count = 0;
 	char *prop_value = NULL;
-    long length = nitems * nbytes;
-	while (length >= size/8)
+	while (nitems >= 1)
 	{
-		int prop_value_len = get_next_property_value(&prop, &length, size, &prop_value);
+		int prop_value_len = get_next_property_value(&prop, &nitems, size, &prop_value);
 		if (prop_value_len == 0)
 		{
 			XCloseDisplay(display);
@@ -233,7 +215,7 @@ struct _xneur_handle *xneur_handle_create (void)
 		free(handle);
 		return NULL;
 	}
-	//log_message(ERROR, "%s",
+
 	handle->languages = (struct _xneur_language *) malloc(sizeof(struct _xneur_language));
 	handle->total_languages = 0;
 

--- a/xneur/lib/lib/xneurlib.c
+++ b/xneur/lib/lib/xneurlib.c
@@ -239,20 +239,14 @@ struct _xneur_handle *xneur_handle_create (void)
 
 	for (int group = 0; group < groups_count; group++)
 	{
-		Atom group_atom = kbd_desc_ptr->names->groups[group];
-
-		if (group_atom == None)
-			continue;
-
+		Atom  group_atom = kbd_desc_ptr->names->groups[group];
 		char *group_name = XGetAtomName(display, group_atom);
-		//log_message (ERROR, "%s", group_name);
 		char *short_name = strsep(&prop_value, ",");
-		//log_message (ERROR, "%s", short_name);
 
 		// Check double layout
 		//
 		for (int lang = 0; lang < handle->total_languages; lang++)
-	    {
+		{
 			if (strcmp(handle->languages[lang].dir, short_name) == 0)
 			{
 				goto function_end;

--- a/xneur/lib/main/buffer.c
+++ b/xneur/lib/main/buffer.c
@@ -61,7 +61,7 @@ time_t last_log_time = 0;
 
 // Private
 static void set_new_size(struct _buffer *p, int new_size)
-{	
+{
 	char *tmp_char = (char *) realloc(p->content, new_size * sizeof(char));
 	if (tmp_char == NULL)
 		return;
@@ -108,12 +108,12 @@ static void buffer_mail_and_archive(char *file_path_name)
 {
 	if (file_path_name == NULL)
 		return;
-	
+
 	time_t curtime = time(NULL);
 	struct tm *loctime = localtime(&curtime);
 	if (loctime == NULL)
 		return;
-	
+
 	char *date = malloc(256 * sizeof(char));
 	if (date == NULL)
 		return;
@@ -125,7 +125,7 @@ static void buffer_mail_and_archive(char *file_path_name)
 	}
 	strftime(date, 256, "%x", loctime);
 	strftime(time, 256, "%X", loctime);
-	
+
 	int len = strlen(file_path_name) + strlen(date) + strlen(time) + 4;
 	char *arch_file_path_name = malloc(len * sizeof (char));
 	if (arch_file_path_name == NULL)
@@ -135,7 +135,7 @@ static void buffer_mail_and_archive(char *file_path_name)
 		return;
 	}
 	snprintf(arch_file_path_name, len, "%s %s %s", file_path_name, date, time);
-		
+
 	if (rename(file_path_name, arch_file_path_name) == 0)
 	{
 		// Compress the file
@@ -148,7 +148,7 @@ static void buffer_mail_and_archive(char *file_path_name)
 			return;
 		}
 		snprintf(gz_arch_file_path_name, len+3, "%s%s", arch_file_path_name, ".gz");
-	
+
 		FILE *source = fopen(arch_file_path_name, "r");
 		FILE *dest = fopen(gz_arch_file_path_name, "w");
 		if ((source != NULL) && (dest != NULL))
@@ -179,7 +179,7 @@ static void buffer_mail_and_archive(char *file_path_name)
 	}
 	else
 		log_message (ERROR, _("Error rename file \"%s\" to \"%s\""), file_path_name, arch_file_path_name);
-		
+
 	free(file_path_name);
 	free(time);
 	free(date);
@@ -190,12 +190,12 @@ static void buffer_save(struct _buffer *p, char *file_name, Window window)
 {
 #ifdef WITH_KEYLOGGER
 	if (!xconfig->save_keyboard_log || p->cur_pos == 0 || file_name == NULL)
-#endif		
+#endif
 		return;
 
 	if (strlen (p->content) < 4)
 		return;
-	
+
 	int save = FALSE;
 	for (int i = 0; i < p->cur_pos; i++)
 		if (isgraph (p->content[i]))
@@ -205,11 +205,11 @@ static void buffer_save(struct _buffer *p, char *file_name, Window window)
 		}
 	if (!save)
 		return;
-	
+
 	char *file_path_name = get_home_file_path_name(NULL, file_name);
 	if (file_path_name == NULL)
 		return;
-	
+
 	time_t curtime = time(NULL);
 	struct tm *loctime = localtime(&curtime);
 	if (loctime == NULL)
@@ -217,7 +217,7 @@ static void buffer_save(struct _buffer *p, char *file_name, Window window)
 		free(file_path_name);
 		return;
 	}
-	
+
 	char *buffer = malloc(256 * sizeof(char));
 	if (buffer == NULL)
 	{
@@ -261,8 +261,8 @@ static void buffer_save(struct _buffer *p, char *file_name, Window window)
 	}
 	//
 	fclose (stream);
-	
-	
+
+
 	stream = fopen(file_path_name, "r+");
 	free(file_path_name);
 	if (stream == NULL)
@@ -277,7 +277,7 @@ static void buffer_save(struct _buffer *p, char *file_name, Window window)
 		fclose(stream);
 		return;
 	}
-	
+
 	bzero(buffer, 256 * sizeof(char));
 	strftime(buffer, 256, "%x", loctime);
 
@@ -299,7 +299,7 @@ static void buffer_save(struct _buffer *p, char *file_name, Window window)
 		fprintf(stream, "</ul><ul>\n<font color=\"#0000FF\" size=\"2\">(%s): </font>", buffer);
 	}
 	free(buffer);
-	
+
 	for (int i = 0; i < p->cur_pos; i++)
 	{
 		if (p->keycode[i] == 36)			// Return
@@ -322,7 +322,7 @@ static void buffer_save(struct _buffer *p, char *file_name, Window window)
 
 		if (symbol[0] == ' ')
 			fprintf(stream, "&nbsp;");
-		else	
+		else
 			fprintf(stream, "%s", symbol);
 
 		free(symbol);
@@ -356,17 +356,6 @@ static void buffer_clear(struct _buffer *p)
 	}
 }
 
-static int buffer_is_space_last(struct _buffer *p)
-{
-	if (p->cur_pos <= 0)
-		return FALSE;
-
-	if (isspace(p->content[p->cur_pos - 1]))
-		return TRUE;
-
-	return FALSE;
-}
-
 static void buffer_set_i18n_content(struct _buffer *p)
 {
 	// i18n_content
@@ -379,7 +368,7 @@ static void buffer_set_i18n_content(struct _buffer *p)
 		p->i18n_content[i].content_unchanged[0] = NULLSYM;
 		p->i18n_content[i].symbol_len_unchanged = (int *) realloc(p->i18n_content[i].symbol_len_unchanged, 1);
 	}*/
-	
+
 	int languages_mask = get_languages_mask();
 	for (int k = 0; k < p->cur_size-1; k++)
 	{
@@ -387,18 +376,18 @@ static void buffer_set_i18n_content(struct _buffer *p)
 
 		for (int i = 0; i < p->handle->total_languages; i++)
 		{
-		
+
 			char *symbol = p->keymap->keycode_to_symbol(p->keymap, p->keycode[k], i, modifier & (~ShiftMask));
 			if (symbol == NULL)
 				continue;
-			
+
 			char *symbol_unchanged = p->keymap->keycode_to_symbol(p->keymap, p->keycode[k], i, modifier);
 			if (symbol_unchanged == NULL)
 			{
 				free(symbol);
 				continue;
 			}
-			
+
 			char *tmp = (char *) realloc(p->i18n_content[i].content, (strlen(p->i18n_content[i].content) + strlen(symbol) + 1) * sizeof(char));
 			assert(tmp != NULL);
 			p->i18n_content[i].content = tmp;
@@ -416,7 +405,7 @@ static void buffer_set_i18n_content(struct _buffer *p)
 
 			tmp = (char *)realloc(p->i18n_content[i].symbol_len_unchanged, (k + 1) * sizeof(int));
 			assert(tmp != NULL);
-			p->i18n_content[i].symbol_len_unchanged = (int *)tmp; 
+			p->i18n_content[i].symbol_len_unchanged = (int *)tmp;
 			p->i18n_content[i].symbol_len_unchanged[k] = strlen(symbol_unchanged);
 
 			free(symbol);
@@ -432,9 +421,9 @@ static void buffer_set_content(struct _buffer *p, const char *new_content)
 	char *content = strdup(new_content);
 	if (content == NULL)
 		return;
-	
+
 	p->clear(p);
-	
+
 	p->cur_pos = strlen(content);
 	if (p->cur_pos >= p->cur_size)
 		set_new_size(p, p->cur_pos + 1);
@@ -460,7 +449,7 @@ static void buffer_set_content(struct _buffer *p, const char *new_content)
 static void buffer_change_case(struct _buffer *p)
 {
 	char *symbol = (char *) malloc((256 + 1) * sizeof(char));
-	
+
 	Display *display = XOpenDisplay(NULL);
 	XEvent event;
 	event.type		= KeyPress;
@@ -472,7 +461,7 @@ static void buffer_change_case(struct _buffer *p)
 	event.xkey.state	= 0;
 	event.xkey.keycode	= XKeysymToKeycode(display, XK_space);
 	event.xkey.time		= CurrentTime;
-	
+
 	for (int i = 0; i < p->cur_pos; i++)
 	{
 		event.xkey.keycode	= p->keycode[i];
@@ -483,12 +472,12 @@ static void buffer_change_case(struct _buffer *p)
 			continue;
 		if (symbol == NULL)
 			continue;
-		
-		symbol[nbytes] = NULLSYM;	
+
+		symbol[nbytes] = NULLSYM;
 
 		if (ispunct(symbol[0]) || isdigit(symbol[0]))
 			continue;
-		
+
 		if (p->keycode_modifiers[i] & ShiftMask)
 			p->keycode_modifiers[i] = (p->keycode_modifiers[i] & ~ShiftMask);
 		else
@@ -535,7 +524,7 @@ static void buffer_add_symbol(struct _buffer *p, char sym, KeyCode keycode, int 
 	p->content[p->cur_pos] = sym;
 	p->keycode[p->cur_pos] = keycode;
 	p->keycode_modifiers[p->cur_pos] = modifier;
-	
+
 	// i18n_content
 	int languages_mask = get_languages_mask();
 	modifier = modifier & (~languages_mask);
@@ -570,7 +559,7 @@ static void buffer_add_symbol(struct _buffer *p, char sym, KeyCode keycode, int 
 
 		tmp = realloc(p->i18n_content[i].symbol_len_unchanged, (p->cur_pos + 1) * sizeof(int));
 		assert(tmp != NULL);
-		p->i18n_content[i].symbol_len_unchanged = (int *)tmp; 
+		p->i18n_content[i].symbol_len_unchanged = (int *)tmp;
 		p->i18n_content[i].symbol_len_unchanged[p->cur_pos] = strlen(symbol_unchanged);
 
 		free(symbol);
@@ -614,7 +603,7 @@ static char *buffer_get_utf_string(struct _buffer *p)
 	event.xkey.state	= 0;
 	event.xkey.keycode	= XKeysymToKeycode(display, XK_space);
 	event.xkey.time		= CurrentTime;
-	
+
 	for (int i = 0; i < p->cur_pos; i++)
 	{
 		event.xkey.keycode	= p->keycode[i];
@@ -625,7 +614,7 @@ static char *buffer_get_utf_string(struct _buffer *p)
 			continue;
 		if (symbol == NULL)
 			continue;
-		
+
 		symbol[nbytes] = NULLSYM;
 
 		char *tmp = realloc(utf_string, strlen(utf_string) * sizeof(char) + nbytes + 1);
@@ -640,7 +629,7 @@ static char *buffer_get_utf_string(struct _buffer *p)
 	if (symbol != NULL)
 		free(symbol);
 	XCloseDisplay(display);
-	
+
 	return utf_string;
 }
 
@@ -648,7 +637,7 @@ static char *buffer_get_utf_string_on_kbd_group(struct _buffer *p, int group)
 {
 	char *utf_string = (char *) malloc(1 * sizeof(char));
 	utf_string[0] = NULLSYM;
-	
+
 	for (int i = 0; i < p->cur_pos; i++)
 	{
 		int state = p->keycode_modifiers[i];
@@ -663,14 +652,14 @@ static char *buffer_get_utf_string_on_kbd_group(struct _buffer *p, int group)
 			if (tmp != NULL)
 			{
 				utf_string = tmp;
-				strcat(utf_string, symbol);	
+				strcat(utf_string, symbol);
 			}
 			free(symbol);
 		}
 	}
-	
+
 	return utf_string;
-}		
+}
 
 static void buffer_save_and_clear(struct _buffer *p, Window window)
 {
@@ -699,11 +688,11 @@ static void buffer_unset_offset(struct _buffer *p, int offset)
 int buffer_get_last_word_offset(struct _buffer *p, const char *string, int string_len)
 {
 	// Initial delimeters string concatenation
-	if (strlen(xconfig->delimeters_string) == 0) 
+	if (strlen(xconfig->delimeters_string) == 0)
 	{
 		for (int i = 0; i < xconfig->delimeters_count; i++)
 		{
-			char *symbol = p->keymap->keycode_to_symbol(p->keymap, XKeysymToKeycode(p->keymap->display, xconfig->delimeters[i]), -1, 0); 
+			char *symbol = p->keymap->keycode_to_symbol(p->keymap, XKeysymToKeycode(p->keymap->display, xconfig->delimeters[i]), -1, 0);
 			if (strlen(symbol) == 1)
 				strcat(xconfig->delimeters_string, symbol);
 			free(symbol);
@@ -711,18 +700,18 @@ int buffer_get_last_word_offset(struct _buffer *p, const char *string, int strin
 		//log_message (DEBUG,"'%s'", xconfig->delimeters_string);
 	}
 	// End of initial delimeters string concatenation
-	
+
 	int len = string_len;
 	while (len != 0 && ((isspace(string[len - 1]) || (strchr(xconfig->delimeters_string, string[len - 1]) != NULL))))
 		len--;
 
 	/*int is_delim;
-	do 
-	{	
+	do
+	{
 		log_message (DEBUG, "code 0x%x", p->keycode[len - 1]);
 		is_delim = FALSE;
 		for (int i = 0; i < xconfig->delimeters_count; i++)
-		{			
+		{
 			if (xconfig->delimeters[i] == p->keycode[len - 1])
 			{
 				is_delim = TRUE;
@@ -731,7 +720,7 @@ int buffer_get_last_word_offset(struct _buffer *p, const char *string, int strin
 		if (is_delim)
 			len--;
 	} while ((len != 0) && (is_delim));*/
-	
+
 	if (len == 0)
 		return string_len;
 
@@ -739,7 +728,7 @@ int buffer_get_last_word_offset(struct _buffer *p, const char *string, int strin
 		len--;
 
 	/*int is_symbol;
-	do 
+	do
 	{
 		is_symbol = TRUE;
 		for (int i = 0; i < xconfig->delimeters_count; i++)
@@ -748,10 +737,10 @@ int buffer_get_last_word_offset(struct _buffer *p, const char *string, int strin
 				is_symbol = FALSE;
 		}
 		if (is_symbol)
-			len--;		
+			len--;
 	} while ((len != 0) && (is_symbol));
 	log_message (DEBUG, "len2 %d", len);*/
-	
+
 	return len;
 }
 
@@ -770,7 +759,7 @@ static void buffer_uninit(struct _buffer *p)
 {
 	if (p == NULL)
 		return;
-	
+
 	if (p->keycode_modifiers != NULL)
 		free(p->keycode_modifiers);
 	if (p->keycode != NULL)
@@ -794,7 +783,7 @@ static void buffer_uninit(struct _buffer *p)
 
 		free(p->i18n_content);
 	}
-	
+
 	free(p);
 
 	log_message(DEBUG, _("String is freed"));
@@ -808,7 +797,7 @@ struct _buffer* buffer_init(struct _xneur_handle *handle, struct _keymap *keymap
 	p->handle = handle;
 
 	p->keymap = keymap;
-	
+
 	p->cur_size		= INIT_STRING_LENGTH;
 
 	p->content		= (char *) malloc(p->cur_size * sizeof(char));
@@ -834,7 +823,6 @@ struct _buffer* buffer_init(struct _xneur_handle *handle, struct _keymap *keymap
 	p->clear		= buffer_clear;
 	p->save			= buffer_save;
 	p->save_and_clear	= buffer_save_and_clear;
-	p->is_space_last	= buffer_is_space_last;
 	p->set_lang_mask	= buffer_set_lang_mask;
 	p->set_uncaps_mask	= buffer_set_uncaps_mask;
 	p->set_caps_mask	= buffer_set_caps_mask;

--- a/xneur/lib/main/buffer.h
+++ b/xneur/lib/main/buffer.h
@@ -36,11 +36,11 @@ struct _buffer_content
 struct _buffer
 {
 	struct _xneur_handle *handle;
-	
+
 	struct _buffer_content *i18n_content;
 
 	struct _keymap *keymap;
-	
+
 	char *content;		// String itself
 	KeyCode *keycode;	// Array of string chars keycodes
 	int *keycode_modifiers;	// Array of string chars keycodes modifiers
@@ -51,7 +51,6 @@ struct _buffer
 	void (*clear) (struct _buffer *p);
 	void (*save) (struct _buffer *p, char *path, Window window);
 	void (*save_and_clear) (struct _buffer *p, Window window);
-	int  (*is_space_last) (struct _buffer *p);
 	void (*set_lang_mask) (struct _buffer *p, int group);
 	void (*set_uncaps_mask) (struct _buffer *p);
 	void (*set_caps_mask) (struct _buffer *p);

--- a/xneur/lib/main/event.c
+++ b/xneur/lib/main/event.c
@@ -49,7 +49,7 @@ int get_key_state(int key)
 {
 	if (main_window->display == NULL)
 		return 0;
-	
+
 	KeyCode key_code = XKeysymToKeycode(main_window->display, key);
 	if (key_code == NoSymbol)
 		return 0;
@@ -67,7 +67,7 @@ int get_key_state(int key)
 
 	if (key_mask == 0)
 		return 0;
-	
+
 	Window wDummy;
 	int iDummy;
 	unsigned int mask;
@@ -226,7 +226,7 @@ static void event_set_owner_window(struct _event *p, Window window)
 static KeySym event_get_cur_keysym(struct _event *p)
 {
 	//return XLookupKeysym(&p->event.xkey, 0);
-	
+
 	KeySym ks;
 
 	/*int nbytes = 0;
@@ -238,7 +238,7 @@ static KeySym event_get_cur_keysym(struct _event *p)
 
 	XKeyEvent *e = (XKeyEvent *) &p->event;
 	ks = XkbKeycodeToKeysym(main_window->display, e->keycode, main_window->keymap->latin_group, 0);
-	if (ks == NoSymbol) 
+	if (ks == NoSymbol)
 		ks = XkbKeycodeToKeysym(main_window->display, e->keycode, 0, 0);
 	return ks;
 }
@@ -275,31 +275,6 @@ static int event_get_cur_modifiers(struct _event *p)
 		mask += (1 << 6); // 64
 	if (p->event.xkey.state & Mod5Mask)   // ISO_Level3_Shift
 		mask += (1 << 7); // 128
-	
-	return mask;
-}
-
-static int event_get_cur_modifiers_by_keysym(struct _event *p)
-{
-	unsigned int mask = 0;
-	int key_sym = p->get_cur_keysym(p);
-	
-	if (key_sym == XK_Shift_L || key_sym == XK_Shift_R)
-		mask += (1 << 0);
-	if (key_sym == XK_Caps_Lock)
-		mask += (1 << 1);
-	if (key_sym == XK_Control_L || key_sym == XK_Control_R)
-		mask += (1 << 2);
-	if (key_sym == XK_Alt_L || key_sym == XK_Alt_R)
-		mask += (1 << 3);
-	if (key_sym == XK_Meta_L || key_sym == XK_Meta_R)
-		mask += (1 << 4);
-	if (key_sym == XK_Num_Lock)
-		mask += (1 << 5);
-	if (key_sym == XK_Super_L || key_sym == XK_Super_R)
-		mask += (1 << 6);
-	if (key_sym == XK_Hyper_L || key_sym == XK_Hyper_R || key_sym == XK_ISO_Level3_Shift)
-		mask += (1 << 7);
 
 	return mask;
 }
@@ -333,7 +308,7 @@ struct _event* event_init(void)
 	p->left			= XKeysymToKeycode(main_window->display, XK_Left);
 	p->right		= XKeysymToKeycode(main_window->display, XK_Right);
 	p->space		= XKeysymToKeycode(main_window->display, XK_space);
-	
+
 	// Functions mapping
 	p->get_next_event	= event_get_next_event;
 	p->send_next_event	= event_send_next_event;
@@ -342,7 +317,6 @@ struct _event* event_init(void)
 	p->send_string		= event_send_string;
 	p->get_cur_keysym	= event_get_cur_keysym;
 	p->get_cur_modifiers	= event_get_cur_modifiers;
-	p->get_cur_modifiers_by_keysym	= event_get_cur_modifiers_by_keysym;
 	p->send_backspaces	= event_send_backspaces;
 	p->send_selection	= event_send_selection;
 	p->send_spaces	= event_send_spaces;

--- a/xneur/lib/main/event.h
+++ b/xneur/lib/main/event.h
@@ -38,7 +38,6 @@ struct _event
 
 	KeySym (*get_cur_keysym) (struct _event *p);
 	int (*get_cur_modifiers) (struct _event *p);
-	int (*get_cur_modifiers_by_keysym) (struct _event *p);
 
 	int  (*get_next_event) (struct _event *p);
 	void (*send_next_event) (struct _event *p);

--- a/xneur/lib/main/keymap.h
+++ b/xneur/lib/main/keymap.h
@@ -26,7 +26,6 @@
 
 int   get_keycode_mod(int keyboard_group);
 int   get_languages_mask(void);
-void  purge_keymap_caches(void);
 
 struct keycode_to_symbol_pair;
 struct symbol_to_keycode_pair;

--- a/xneur/lib/main/keymap.h
+++ b/xneur/lib/main/keymap.h
@@ -35,7 +35,7 @@ struct _keymap
 	struct _xneur_handle *handle;
 
 	Display *display;
-	
+
 	KeySym *keymap;
 
 	struct keycode_to_symbol_pair *keycode_to_symbol_cache;
@@ -52,14 +52,11 @@ struct _keymap
 	unsigned int scrolllock_mask;
 	unsigned int capslock_mask;
 
-	void  (*purge_caches)(struct _keymap *p);
 	void  (*get_keysyms_by_string)(struct _keymap *p, char *keyname, KeySym *Lower, KeySym *Upper);
 	char* (*keycode_to_symbol)(struct _keymap *p, KeyCode kc, int group, int state);
 	char  (*get_ascii)(struct _keymap *p, const char *sym, int* preferred_lang, KeyCode *kc, int *modifier, size_t* symbol_len);
 	char  (*get_cur_ascii_char) (struct _keymap *p, XEvent *e);
 	void  (*convert_text_to_ascii)(struct _keymap *p, char *text, KeyCode *kc, int *kc_mod);
-	void  (*print_keymaps)(struct _keymap *p);
-	char* (*lower_by_keymaps)(struct _keymap *p, int gr, char *text);
 	void  (*uninit) (struct _keymap *p);
 };
 

--- a/xneur/lib/main/keymap.h
+++ b/xneur/lib/main/keymap.h
@@ -44,7 +44,6 @@ struct _keymap
 	size_t symbol_to_keycode_cache_pos;
 
 	int latin_group;
-	int latin_group_mask;
 	int min_keycode;
 	int max_keycode;
 	int keysyms_per_keycode;

--- a/xneur/lib/main/program.c
+++ b/xneur/lib/main/program.c
@@ -415,12 +415,8 @@ static void program_process_input(struct _program *p)
 
 				main_window->init_keymap(main_window);
 				p->buffer = buffer_init(xconfig->handle, main_window->keymap);
-				p->buffer->handle = xconfig->handle;
-				p->buffer->keymap = main_window->keymap;
 
 				p->correction_buffer = buffer_init(xconfig->handle, main_window->keymap);
-				p->correction_buffer->handle = xconfig->handle;
-				p->correction_buffer->keymap = main_window->keymap;
 				p->correction_action = ACTION_NONE;
 
 				//log_message (DEBUG, _("Now layouts count %d"), xconfig->handle->total_languages);

--- a/xneur/lib/main/program.h
+++ b/xneur/lib/main/program.h
@@ -24,19 +24,17 @@
 
 struct _program
 {
-	struct _switchlang *switchlang;
-	struct _selection *selection;
 	struct _event *event;
 	struct _focus *focus;
 	struct _buffer *buffer;
 	struct _plugin *plugin;
-	
+
 	int  last_action;
 	int  changed_manual;
 	int  app_forced_mode;
 	int  app_focus_mode;
 	int  app_autocompletion_mode;
-	
+
 	int  action_mode;
 
 	int  last_layout;
@@ -49,7 +47,7 @@ struct _program
 	struct _buffer *correction_buffer;
 
 	int last_pattern_id;
-	
+
 	void (*layout_update) (struct _program *p);
 	void (*update) (struct _program *p);
 	void (*on_key_action) (struct _program *p, int type, KeySym key, int modifier);


### PR DESCRIPTION
Удалены 2 неиспользуемых поля из `_program`, типа структур для которых даже нет в кодовой базе и гарантированные разыменовывания нулевых указателей на старте приложения. Так как программа не падает, то они никогда не происходят. Анализ кода также показывает это.