### PR TITLE
Optimizations

### DIFF
--- a/xneur/lib/ai/detection.c
+++ b/xneur/lib/ai/detection.c
@@ -144,7 +144,7 @@ static int get_enchant_hits(struct _xneur_handle *handle, char **word, int **sym
 	// check for another languages
 	for (int lang = 0; lang < handle->total_languages; lang++)
 	{
-		if (handle->languages[lang].disable_auto_detection || handle->languages[lang].excluded || lang == cur_lang || (strlen(word[lang]) <= 0)) 
+		if (handle->languages[lang].disable_auto_detection || handle->languages[lang].excluded || lang == cur_lang || (strlen(word[lang]) <= 0))
 			continue;
 
 		if (strlen(word[lang]) == 0)
@@ -169,7 +169,7 @@ static int get_enchant_hits(struct _xneur_handle *handle, char **word, int **sym
 	log_message(DEBUG, _("   [-] This word has no hits for all enchant wrapper dictionaries"));
 	return NO_LANGUAGE;
 }
-#endif				
+#endif
 
 static int get_proto_hits(struct _xneur_handle *handle, char *word, int *sym_len, int len, int offset, int lang)
 {
@@ -212,7 +212,7 @@ static int get_big_proto_hits(struct _xneur_handle *handle, char *word, int *sym
 		strncpy(proto, word+local_offset, n_bytes);
 		proto[n_bytes] = NULLSYM;
 
-		if (handle->languages[lang].proto->exist(handle->languages[lang].big_proto, proto, BY_PLAIN))
+		if (handle->languages[lang].big_proto->exist(handle->languages[lang].big_proto, proto, BY_PLAIN))
 		{
 			free(proto);
 			return TRUE;
@@ -277,16 +277,16 @@ static int get_similar_words(struct _xneur_handle *handle, struct _buffer *p)
 	int min_levenshtein = LEVENSHTEIN_LEN;
 	char *possible_words = NULL;
 	int possible_lang = NO_LANGUAGE;
-	
+
 	int lang = 0;
 	for (lang = 0; lang < handle->total_languages; lang++)
 	{
 		char *word = strdup(p->get_last_word(p, p->i18n_content[lang].content));
 		if (word == NULL)
 			continue;
-		
+
 		del_final_numeric_char(word);
-		
+
 		if (handle->languages[lang].disable_auto_detection || handle->languages[lang].excluded)
 		{
 			if (possible_words != NULL)
@@ -296,7 +296,7 @@ static int get_similar_words(struct _xneur_handle *handle, struct _buffer *p)
 		}
 
 		int word_len = strlen(p->get_last_word(p, p->content));
-		
+
 		if ((word_len > 250) || (word_len < 2))
 		{
 			if (possible_words != NULL)
@@ -305,18 +305,18 @@ static int get_similar_words(struct _xneur_handle *handle, struct _buffer *p)
 			continue;
 		}
 
-		word_len = strlen(word); 
-		
+		word_len = strlen(word);
+
 		int offset = 0;
 		for (offset = 0; offset < word_len; offset++)
 		{
 			if (!ispunct(word[offset]))
 				break;
 		}
-		
-#ifdef WITH_ENCHANT 
+
+#ifdef WITH_ENCHANT
 		size_t count = 0;
-		
+
 		if (!handle->has_enchant_checker[lang])
 		{
 			if (possible_words != NULL)
@@ -325,7 +325,7 @@ static int get_similar_words(struct _xneur_handle *handle, struct _buffer *p)
 			continue;
 		}
 
-		char **suggs = enchant_dict_suggest (handle->enchant_dicts[lang], word+offset, strlen(word+offset), &count); 
+		char **suggs = enchant_dict_suggest (handle->enchant_dicts[lang], word+offset, strlen(word+offset), &count);
 		if (count > 0)
 		{
 			for (unsigned int i = 0; i < count; i++)
@@ -338,10 +338,10 @@ static int get_similar_words(struct _xneur_handle *handle, struct _buffer *p)
 						free(possible_words);
 					possible_words = strdup(suggs[i]);
 					possible_lang = lang;
-					
+
 				}
-				//log_message (ERROR, "    %d. %s (%d)", i+1, suggs[i], levenshtein(word, suggs[i]));	
-			}			
+				//log_message (ERROR, "    %d. %s (%d)", i+1, suggs[i], levenshtein(word, suggs[i]));
+			}
 		}
 		enchant_dict_free_string_list(handle->enchant_dicts[lang], suggs);
 #endif
@@ -378,27 +378,27 @@ static int get_similar_words(struct _xneur_handle *handle, struct _buffer *p)
 					free(possible_words);
 				possible_words = strdup(sugg_word);
 				possible_lang = lang;
-				
+
 			}
 			i++;
-			//log_message (ERROR, "    %d. %s (%d) (%d)", i, sugg_word, levenshtein(word, sugg_word), damerau_levenshtein(word, sugg_word, 1, 1, 1, 1));	
+			//log_message (ERROR, "    %d. %s (%d) (%d)", i, sugg_word, levenshtein(word, sugg_word), damerau_levenshtein(word, sugg_word, 1, 1, 1, 1));
 		}
 
 		delete_aspell_string_enumeration (elements);
 #endif
 		free(word);
 	}
-	
+
 	if (possible_words == NULL)
 	{
-		log_message(DEBUG, _("   [-] This word has no suggest for all dictionaries")); 
+		log_message(DEBUG, _("   [-] This word has no suggest for all dictionaries"));
 		return possible_lang;
 
 	}
-	
-	log_message(DEBUG, _("   [+] Found suggest word '%s' in %s dictionary (Levenshtein distance = %d)"),  
+
+	log_message(DEBUG, _("   [+] Found suggest word '%s' in %s dictionary (Levenshtein distance = %d)"),
 						possible_words, handle->languages[possible_lang].name, min_levenshtein);
-	free (possible_words); 
+	free (possible_words);
 	return possible_lang;
 }
 
@@ -424,12 +424,12 @@ int check_lang(struct _xneur_handle *handle, struct _buffer *p, int cur_lang)
 				break;
 		}
 		word[i] = word[i] + offset;
-		
+
 		word_unchanged[i] = strdup(p->get_last_word(p, p->i18n_content[i].content_unchanged));
 		word_unchanged_base[i] = word_unchanged[i];
 		word_unchanged[i] = word_unchanged[i] + offset;
 		del_final_numeric_char(word_unchanged[i]);
-		
+
 		log_message(DEBUG, _("   '%s' on layout '%s'"), word_unchanged[i], handle->languages[i].dir);
 
 		sym_len[i] = p->i18n_content[i].symbol_len + p->get_last_word_offset(p, p->content, strlen(p->content));
@@ -451,7 +451,7 @@ int check_lang(struct _xneur_handle *handle, struct _buffer *p, int cur_lang)
 	if (lang == NO_LANGUAGE)
 		lang = get_aspell_hits(handle, word, sym_len, cur_lang);
 #endif
-	
+
 	// If not found in dictionary, try to find in proto
 	int len = strlen(p->content);
 	int offset = p->get_last_word_offset(p, p->content, len);
@@ -468,7 +468,7 @@ int check_lang(struct _xneur_handle *handle, struct _buffer *p, int cur_lang)
 		free(word_base[i]);
 		free(word_unchanged_base[i]);
 	}
-	
+
 	free(word);
 	free(word_unchanged);
 	free(word_base);
@@ -499,12 +499,12 @@ int check_lang_with_similar_words (struct _xneur_handle *handle, struct _buffer 
 				break;
 		}
 		word[i] = word[i] + offset;
-		
+
 		word_unchanged[i] = strdup(p->get_last_word(p, p->i18n_content[i].content_unchanged));
 		word_unchanged_base[i] = word_unchanged[i];
 		word_unchanged[i] = word_unchanged[i] + offset;
 		del_final_numeric_char(word_unchanged[i]);
-		
+
 		log_message(DEBUG, _("   '%s' on layout '%s'"), word_unchanged[i], handle->languages[i].dir);
 
 		sym_len[i] = p->i18n_content[i].symbol_len + p->get_last_word_offset(p, p->content, strlen(p->content));
@@ -530,7 +530,7 @@ int check_lang_with_similar_words (struct _xneur_handle *handle, struct _buffer 
 	// Check misprint
 	if (lang == NO_LANGUAGE)
 		lang = get_similar_words (handle, p);
-	
+
 	// If not found in dictionary, try to find in proto
 	int len = strlen(p->content);
 	int offset = p->get_last_word_offset(p, p->content, len);
@@ -553,5 +553,5 @@ int check_lang_with_similar_words (struct _xneur_handle *handle, struct _buffer 
 	free(word_unchanged_base);
 	free(sym_len);
 	return lang;
-} 
+}
 

--- a/xneur/lib/config/xnconfig.c
+++ b/xneur/lib/config/xnconfig.c
@@ -1125,7 +1125,7 @@ static void free_structures(struct _xneur_config *p)
 	p->dont_send_key_release_apps->uninit(p->dont_send_key_release_apps);
 	p->delay_send_key_apps->uninit(p->delay_send_key_apps);
 	p->abbreviations->uninit(p->abbreviations);
-	
+
 	p->plugins->uninit(p->plugins);
 
 
@@ -1179,7 +1179,7 @@ static void free_structures(struct _xneur_config *p)
 
 	//if (p->actions != NULL)
 	//	free(p->actions);
-	
+
 	//if (p->user_actions != NULL)
 	//	free(p->user_actions);
 }
@@ -1394,7 +1394,7 @@ static int xneur_config_save(struct _xneur_config *p)
 		fprintf(stream, "SetManualApp %s\n", p->manual_apps->data[i].string);
 	fprintf(stream, "\n");
 
-	
+
 	fprintf(stream, "# Binds hotkeys for some actions\n");
 	for (int action = 0; action < p->actions_count; action++)
 	{
@@ -1787,18 +1787,6 @@ static void xneur_config_save_pattern(struct _xneur_config *p, int lang)
 		free(lang_dir);
 }
 
-static char* xneur_config_get_lang_dir(struct _xneur_config *p, int lang)
-{
-	if (lang < 0 || lang >= p->handle->total_languages)
-		return NULL;
-
-	int path_len = strlen(LANGUAGEDIR) + strlen(p->handle->languages[lang].dir) + 2;
-	char *path_file = (char *) malloc(path_len * sizeof(char));
-	snprintf(path_file, path_len, "%s/%s", LANGUAGEDIR, p->handle->languages[lang].dir);
-
-	return path_file;
-}
-
 static const char* xneur_config_get_log_level_name(struct _xneur_config *p)
 {
 	return log_levels[p->log_level];
@@ -1813,7 +1801,7 @@ static void xneur_config_uninit(struct _xneur_config *p)
 
 	free(p->actions);
 	free(p->user_actions);
-	
+
 	free(p->sounds);
 	free(p->osds);
 	free(p->popups);
@@ -1824,13 +1812,13 @@ static void xneur_config_uninit(struct _xneur_config *p)
 		free(p->delimeters_string);
 	p->delimeters_count = 0;
 
-	if (p->mail_keyboard_log != NULL) 
+	if (p->mail_keyboard_log != NULL)
 		free(p->mail_keyboard_log);
-	if (p->host_keyboard_log != NULL) 
+	if (p->host_keyboard_log != NULL)
 		free(p->host_keyboard_log);
 
 	xneur_handle_destroy(p->handle);
-	
+
 	free(p);
 }
 
@@ -1908,7 +1896,6 @@ struct _xneur_config* xneur_config_init(void)
 	p->save_pattern			= xneur_config_save_pattern;
 	p->set_pid			= xneur_config_set_pid;
 	p->get_pid			= xneur_config_get_pid;
-	p->get_lang_dir		= xneur_config_get_lang_dir;
 	p->get_log_level_name		= xneur_config_get_log_level_name;
 
 	p->uninit			= xneur_config_uninit;

--- a/xneur/lib/config/xnconfig.h
+++ b/xneur/lib/config/xnconfig.h
@@ -205,11 +205,11 @@ struct _xneur_config
 	struct _list_char *plugins;
 
 	struct _xneur_handle *handle;		// Array of languages used in program
-	
+
 	struct _xneur_notify *sounds;			// Array of sounds for actions
 	struct _xneur_notify *osds;			// Array of OSDs for actions
 	struct _xneur_notify *popups;			// Array of popups for actions
-	
+
 	struct _xneur_action *actions;			// Array of hotkeys used in program
 	int actions_count;				// Count of hotkeys
 
@@ -302,7 +302,6 @@ struct _xneur_config
 	void  (*save_pattern) (struct _xneur_config *p, int lang);
 	pid_t (*set_pid) (struct _xneur_config *p, pid_t pid);
 	pid_t (*get_pid) (struct _xneur_config *p);
-	char* (*get_lang_dir) (struct _xneur_config *p, int lang);
 	const char* (*get_log_level_name) (struct _xneur_config *p);
 	void  (*uninit) (struct _xneur_config *p);
 };

--- a/xneur/lib/misc/list_char.c
+++ b/xneur/lib/misc/list_char.c
@@ -208,14 +208,15 @@ struct _list_char_data* list_char_find(struct _list_char *list, const char *stri
 
 struct _list_char_data* list_char_find_alike(struct _list_char *list, const char *string)
 {
-	if (strlen(string) < 4)
+	size_t len = strlen(string);
+	if (len < 4)
 		return NULL;
 	
 	int id = get_add_id(list, string);
 	if ((id == -1) || (id == list->data_count))
 		return NULL;
 
-	if (strncmp(list->data[id].string, string, strlen(string)) != 0)
+	if (strncmp(list->data[id].string, string, len) != 0)
 		return NULL;
 
 	return &list->data[id];
@@ -223,21 +224,22 @@ struct _list_char_data* list_char_find_alike(struct _list_char *list, const char
 
 struct _list_char* list_char_alike(struct _list_char *list, const char *string)
 {
-	if (strlen(string) < 4)
+	size_t len = strlen(string);
+	if (len < 4)
 		return NULL;
 	
 	int id = get_add_id(list, string);
 	if ((id == -1) || (id == list->data_count))
 		return NULL;
 
-	if (strncmp(list->data[id].string, string, strlen(string)) != 0)
+	if (strncmp(list->data[id].string, string, len) != 0)
 		return NULL;
 
 	struct _list_char* list_alike = list_char_init();
 	
 	for (int i = id; i < list->data_count; i++)
 	{
-		if (strncmp(list->data[i].string, string, strlen(string)) != 0)
+		if (strncmp(list->data[i].string, string, len) != 0)
 			break;
 		add_last(list_alike, list->data[i].string);
 	}

--- a/xneur/lib/misc/list_char.c
+++ b/xneur/lib/misc/list_char.c
@@ -47,7 +47,7 @@ static void rem_by_id(struct _list_char *list, int id)
 
 	list->data_count--;
 	struct _list_char_data *tmp = realloc(list->data, list->data_count * sizeof(struct _list_char_data));
-	if (tmp != NULL) 
+	if (tmp != NULL)
 		list->data = tmp;
 }
 
@@ -81,7 +81,7 @@ static int find_id(struct _list_char *list, const char *string, int mode)
 {
 	if (list->data_count == 0)
 		return -1;
-	
+
 	if (mode == BY_PLAIN)
 	{
 		// Print all list for debug
@@ -90,8 +90,8 @@ static int find_id(struct _list_char *list, const char *string, int mode)
 			struct _list_char_data *data = &list->data[0];
 			data = &list->data[i];
 			log_message (ERROR, "%d %s", i, data->string);
-		}*/ 
-		
+		}*/
+
 		int first = 0;
 		int last = list->data_count - 1;
 
@@ -133,11 +133,11 @@ static int find_id(struct _list_char *list, const char *string, int mode)
 			//data = &list->data[i];
 			strcat(full_str, data->string);
 			strcat(full_str, "|");
-		} 
+		}
 
 		struct _list_char_data *data;
 		data = &list->data[list->data_count - 1];
-		strcat(full_str, data->string);			
+		strcat(full_str, data->string);
 
 		if (check_regexp_match(string, full_str))
 		{
@@ -152,7 +152,7 @@ static int find_id(struct _list_char *list, const char *string, int mode)
 }
 
 static struct _list_char_data* add_last(struct _list_char *list, const char *string)
-{	
+{
 	list->data_count++;
 	struct _list_char_data *tmp = (struct _list_char_data *)realloc(list->data, list->data_count * sizeof(struct _list_char_data));
 	if (tmp == NULL)
@@ -172,13 +172,13 @@ struct _list_char_data* list_char_add(struct _list_char *list, const char *strin
 {
 	int id = get_add_id(list, string);
 
-	struct _list_char_data *tmp = realloc(list->data, (list->data_count + 1) * sizeof(struct _list_char_data)); 
+	struct _list_char_data *tmp = realloc(list->data, (list->data_count + 1) * sizeof(struct _list_char_data));
 	if (tmp == NULL)
 	{
 		log_message (ERROR, _("Function realloc return NULL."));
 		return NULL;
 	}
-	
+
 	list->data = (struct _list_char_data *)tmp;
 	if (id != list->data_count)
 		memmove(list->data + id + 1, list->data + id, (list->data_count - id) * sizeof(struct _list_char_data));
@@ -197,21 +197,12 @@ void list_char_rem(struct _list_char *list, const char *string)
 	rem_by_id(list, id);
 }
 
-struct _list_char_data* list_char_find(struct _list_char *list, const char *string, int mode)
-{
-	int id = find_id(list, string, mode);
-	if (id == -1)
-		return NULL;
-
-	return &list->data[id];
-}
-
 struct _list_char_data* list_char_find_alike(struct _list_char *list, const char *string)
 {
 	size_t len = strlen(string);
 	if (len < 4)
 		return NULL;
-	
+
 	int id = get_add_id(list, string);
 	if ((id == -1) || (id == list->data_count))
 		return NULL;
@@ -227,7 +218,7 @@ struct _list_char* list_char_alike(struct _list_char *list, const char *string)
 	size_t len = strlen(string);
 	if (len < 4)
 		return NULL;
-	
+
 	int id = get_add_id(list, string);
 	if ((id == -1) || (id == list->data_count))
 		return NULL;
@@ -236,7 +227,7 @@ struct _list_char* list_char_alike(struct _list_char *list, const char *string)
 		return NULL;
 
 	struct _list_char* list_alike = list_char_init();
-	
+
 	for (int i = id; i < list->data_count; i++)
 	{
 		if (strncmp(list->data[i].string, string, len) != 0)
@@ -248,8 +239,7 @@ struct _list_char* list_char_alike(struct _list_char *list, const char *string)
 
 int list_char_exist(struct _list_char *list, const char *string, int mode)
 {
-	struct _list_char_data *data = list->find(list, string, mode);
-	return (data != NULL);
+	return find_id(list, string, mode) != -1;
 }
 
 struct _list_char* list_char_clone(struct _list_char *list)
@@ -276,10 +266,10 @@ void list_char_sort(struct _list_char *list)
 	// Insertion sort
 	int i, j;
 	struct _list_char_data temp;
-	for (i = 1; i < list->data_count; i++) 
+	for (i = 1; i < list->data_count; i++)
 	{
 		temp = list->data[i];
-		for (j = i - 1; j >= 0; j--) 
+		for (j = i - 1; j >= 0; j--)
 		{
 			data1 = list->data[j].string;
 			data2 = temp.string;
@@ -358,7 +348,7 @@ void list_char_sort(struct _list_char *list)
 	}
 	while (i >= 1);
 	*/
-	
+
 	for (int i = 0; i < list->data_count - 1; i++)
 	{
 		if (strcmp(list->data[i].string, list->data[i+1].string) > 0)
@@ -405,11 +395,10 @@ struct _list_char* list_char_init(void)
 	bzero(list, sizeof(struct _list_char));
 
 	list->data_count = 0;
-	
+
 	list->uninit	= list_char_uninit;
 	list->add	= list_char_add;
 	list->rem	= list_char_rem;
-	list->find	= list_char_find;
 	list->find_alike	= list_char_find_alike;
 	list->load	= list_char_load;
 	list->save	= list_char_save;

--- a/xneur/lib/misc/list_char.c
+++ b/xneur/lib/misc/list_char.c
@@ -256,8 +256,12 @@ struct _list_char* list_char_clone(struct _list_char *list)
 {
 	struct _list_char *list_copy = list_char_init();
 
-	for (int i = 0; i < list->data_count; i++)
-		add_last(list_copy, list->data[i].string);
+	list_copy->data = (struct _list_char_data *) malloc(list->data_count * sizeof(struct _list_char_data));
+	list_copy->data_count = list->data_count;
+
+	for (int i = 0; i < list->data_count; i++) {
+		list_copy->data[i].string = strdup(list->data[i].string);
+	}
 
 	list_copy->sort(list_copy);
 

--- a/xneur/lib/misc/list_char.c
+++ b/xneur/lib/misc/list_char.c
@@ -263,8 +263,6 @@ struct _list_char* list_char_clone(struct _list_char *list)
 		list_copy->data[i].string = strdup(list->data[i].string);
 	}
 
-	list_copy->sort(list_copy);
-
 	return list_copy;
 }
 

--- a/xneur/lib/misc/list_char.h
+++ b/xneur/lib/misc/list_char.h
@@ -42,7 +42,6 @@ struct _list_char
 
 	void (*uninit) (struct _list_char *list);
 	struct _list_char_data* (*add) (struct _list_char *list, const char *string);
-	struct _list_char_data* (*find) (struct _list_char *list, const char *string, int mode);
 	struct _list_char_data* (*find_alike) (struct _list_char *list, const char *string);
 	struct _list_char* (*clone) (struct _list_char *list);
 	struct _list_char* (*alike) (struct _list_char *list, const char *string);

--- a/xneur/src/newlang_creation.c
+++ b/xneur/src/newlang_creation.c
@@ -57,7 +57,7 @@ void generate_protos(void)
 
 	printf("\nSpecified new language group: %d\n", new_lang_group);
 	char *path = get_file_path_name(NEW_LANG_DIR, NEW_LANG_TEXT);
-	if (path == NULL) 
+	if (path == NULL)
 		return;
 	char *text = get_file_content(path);
 	free(path);
@@ -92,7 +92,7 @@ void generate_protos(void)
 			strcpy(syll, sym_i);
 			strcat(syll, sym_j);
 
-			if (proto->find(proto, syll, BY_PLAIN))
+			if (proto->exist(proto, syll, BY_PLAIN))
 				continue;
 
 			if (strstr(text, syll) == NULL)
@@ -111,7 +111,7 @@ void generate_protos(void)
 
 				sprintf(syll, "%s%s%s", sym_i, sym_j, sym_k);
 
-				if (proto3->find(proto3, syll, BY_PLAIN))
+				if (proto3->exist(proto3, syll, BY_PLAIN))
 					continue;
 
 				if (strstr(text, syll) != NULL)
@@ -140,7 +140,7 @@ void generate_protos(void)
 			strcpy(syll, sym_i);
 			strcat(syll, sym_j);
 
-			if (proto->find(proto, syll, BY_PLAIN))
+			if (proto->exist(proto, syll, BY_PLAIN))
 				continue;
 
 			if (strstr(text, syll) == NULL)
@@ -159,7 +159,7 @@ void generate_protos(void)
 
 				sprintf(syll, "%s%s%s", sym_i, sym_j, sym_k);
 
-				if (proto3->find(proto3, syll, BY_PLAIN))
+				if (proto3->exist(proto3, syll, BY_PLAIN))
 					continue;
 
 				if (strstr(text, syll) != NULL)


### PR DESCRIPTION
Небольшое количество малых оптимизаций и незначительный фикс в 1cdb597

- Удалены некоторые неиспользуемые функции
- Устранен вызов `strlen` в цикле, т.к. аргумент не меняется
- При клонировании списка выделяем память лишь один раз а не реаллокейтим ее по мере клонирования
- Удалена ненужная сортировка при клонировании списка, т.к. функция клонирования используется только в одном месте, а там список на входе уже отсортирован