### PR TITLE
Устранен дублирующийся код и некоторый рефакторинг

### DIFF
--- a/xneur/lib/main/buffer.c
+++ b/xneur/lib/main/buffer.c
@@ -85,7 +85,7 @@ static void buffer_set_lang_mask(struct _buffer *p, int lang)
 	// Set new language bit
 	for (int i = 0; i < p->cur_pos; i++)
 	{
-		p->keycode_modifiers[i] = p->keycode_modifiers[i] & (~languages_mask);
+		p->keycode_modifiers[i] = p->keycode_modifiers[i] & languages_mask;
 		p->keycode_modifiers[i] = p->keycode_modifiers[i] | keycode_mod;
 	}
 }
@@ -360,7 +360,7 @@ static void buffer_clear(struct _buffer *p)
 static void append_to_i18n_content(struct _buffer *buf, int pos, int languages_mask)
 {
 	KeyCode keycode = buf->keycode[pos];
-	int modifier    = buf->keycode_modifiers[pos] & (~languages_mask);
+	int modifier    = buf->keycode_modifiers[pos] & languages_mask;
 
 	for (int i = 0; i < buf->handle->total_languages; i++)
 	{
@@ -488,7 +488,7 @@ static void buffer_rotate_layout(struct _buffer *p)
 	for (int i = 0; i < p->cur_pos; i++)
 	{
 		// Get current lang. modifier
-		int km = p->keycode_modifiers[i] & (~languages_mask);
+		int km = p->keycode_modifiers[i] & languages_mask;
 		for (int lang = 0; lang < p->handle->total_languages; lang++)
 		{
 			if (p->keycode_modifiers[i] == (get_keycode_mod(lang) | km))
@@ -497,7 +497,7 @@ static void buffer_rotate_layout(struct _buffer *p)
 				if (lang == p->handle->total_languages)
 					lang = 0;
 				int keycode_mod	= get_keycode_mod(lang);
-				p->keycode_modifiers[i] = p->keycode_modifiers[i] & (~languages_mask);
+				p->keycode_modifiers[i] = p->keycode_modifiers[i] & languages_mask;
 				p->keycode_modifiers[i] = p->keycode_modifiers[i] | keycode_mod;
 				break;
 			}

--- a/xneur/lib/main/buffer.c
+++ b/xneur/lib/main/buffer.c
@@ -444,23 +444,22 @@ static void buffer_change_case(struct _buffer *p)
 	char *symbol = (char *) malloc((256 + 1) * sizeof(char));
 
 	Display *display = XOpenDisplay(NULL);
-	XEvent event;
-	event.type		= KeyPress;
-	event.xkey.type		= KeyPress;
-	event.xkey.root		= RootWindow(display, DefaultScreen(display));
-	event.xkey.subwindow	= None;
-	event.xkey.same_screen	= True;
-	event.xkey.display	= display;
-	event.xkey.state	= 0;
-	event.xkey.keycode	= XKeysymToKeycode(display, XK_space);
-	event.xkey.time		= CurrentTime;
+	XKeyEvent event;
+	event.type        = KeyPress;
+	event.root        = RootWindow(display, DefaultScreen(display));
+	event.subwindow   = None;
+	event.same_screen = True;
+	event.display     = display;
+	event.state       = 0;
+	event.keycode     = XKeysymToKeycode(display, XK_space);
+	event.time        = CurrentTime;
 
 	for (int i = 0; i < p->cur_pos; i++)
 	{
-		event.xkey.keycode	= p->keycode[i];
-		event.xkey.state	= p->keycode_modifiers[i];
+		event.keycode = p->keycode[i];
+		event.state   = p->keycode_modifiers[i];
 
-		int nbytes = XLookupString((XKeyEvent *) &event, symbol, 256, NULL, NULL);
+		int nbytes = XLookupString(&event, symbol, 256, NULL, NULL);
 		if (nbytes <= 0)
 			continue;
 		if (symbol == NULL)
@@ -547,23 +546,22 @@ static char *buffer_get_utf_string(struct _buffer *p)
 	utf_string[0] = NULLSYM;
 
 	Display *display = XOpenDisplay(NULL);
-	XEvent event;
-	event.type		= KeyPress;
-	event.xkey.type		= KeyPress;
-	event.xkey.root		= RootWindow(display, DefaultScreen(display));
-	event.xkey.subwindow	= None;
-	event.xkey.same_screen	= True;
-	event.xkey.display	= display;
-	event.xkey.state	= 0;
-	event.xkey.keycode	= XKeysymToKeycode(display, XK_space);
-	event.xkey.time		= CurrentTime;
+	XKeyEvent event;
+	event.type        = KeyPress;
+	event.root        = RootWindow(display, DefaultScreen(display));
+	event.subwindow   = None;
+	event.same_screen = True;
+	event.display     = display;
+	event.state       = 0;
+	event.keycode     = XKeysymToKeycode(display, XK_space);
+	event.time        = CurrentTime;
 
 	for (int i = 0; i < p->cur_pos; i++)
 	{
-		event.xkey.keycode	= p->keycode[i];
-		event.xkey.state	= p->keycode_modifiers[i];
+		event.keycode = p->keycode[i];
+		event.state   = p->keycode_modifiers[i];
 
-		int nbytes = XLookupString((XKeyEvent *) &event, symbol, 256, NULL, NULL);
+		int nbytes = XLookupString(&event, symbol, 256, NULL, NULL);
 		if (nbytes <= 0)
 			continue;
 		if (symbol == NULL)

--- a/xneur/lib/main/event.c
+++ b/xneur/lib/main/event.c
@@ -245,18 +245,6 @@ static KeySym event_get_cur_keysym(struct _event *p)
 
 static int event_get_cur_modifiers(struct _event *p)
 {
-	/*
-	Window wDummy;
-	int iDummy;
-	int mask = 0;
-	unsigned int query_mask;
-	XQueryPointer(main_window->display,
-				(Window)p->event.xkey.window,
-				&wDummy, &wDummy, &iDummy, &iDummy, &iDummy, &iDummy,
-				&query_mask);
-	mask = query_mask & (~get_languages_mask ());
-	*/
-
 	int mask = 0;
 
 	if (p->event.xkey.state & ShiftMask)  // Shift

--- a/xneur/lib/main/keymap.c
+++ b/xneur/lib/main/keymap.c
@@ -148,7 +148,6 @@ static char* keymap_keycode_to_symbol_real(struct _keymap *p, KeyCode kc, int gr
 
 static char* keymap_keycode_to_symbol(struct _keymap *p, KeyCode kc, int group, int state)
 {
-	char *symbol;
 	struct keycode_to_symbol_pair *pr = NULL;
 
 	/* Look up cache. */
@@ -160,9 +159,7 @@ static char* keymap_keycode_to_symbol(struct _keymap *p, KeyCode kc, int group, 
 
 	/* Miss. */
 	//log_message (TRACE, "Symbol at KeyCode %d not found on cache! ", kc);
-	symbol = keymap_keycode_to_symbol_real(p, kc, group, state);
-	if (!symbol)
-		return symbol;
+	char *symbol = keymap_keycode_to_symbol_real(p, kc, group, state);
 
 	/* Just use next cache entry. LRU makes no sense here. */
 	p->keycode_to_symbol_cache_pos = (p->keycode_to_symbol_cache_pos + 1) % keycode_to_symbol_cache_size;

--- a/xneur/lib/main/keymap.c
+++ b/xneur/lib/main/keymap.c
@@ -80,7 +80,7 @@ int get_languages_mask(void)
 	int languages_mask = 0;
 	for (int group = 0; group < 4; group++)
 		languages_mask = languages_mask | keyboard_groups[group];
-	return languages_mask;
+	return ~languages_mask;
 }
 
 static char* keymap_keycode_to_symbol_real(struct _keymap *p, KeyCode kc, int group, int state)

--- a/xneur/lib/main/program.c
+++ b/xneur/lib/main/program.c
@@ -1455,6 +1455,33 @@ static int program_perform_action(struct _program *p, enum _hotkey_action action
 	return TRUE;
 }
 
+static int change(struct _program *p, int action, int check_similar_words)
+{
+	int cur_lang = get_curr_keyboard_group();
+	int new_lang = check_similar_words
+		? check_lang_with_similar_words(xconfig->handle, p->buffer, cur_lang)
+		: check_lang(xconfig->handle, p->buffer, cur_lang);
+
+	if (new_lang == NO_LANGUAGE)
+	{
+		log_message(DEBUG, _("No language found to change to"));
+		return FALSE;
+	}
+
+	if (new_lang == cur_lang)
+	{
+		return FALSE;
+	}
+
+	// TODO: We support only up to 4 different languages
+	program_change_word(p, action + (new_lang > 3 ? 3 : new_lang));
+	show_notify(NOTIFY_AUTOMATIC_CHANGE_WORD, NULL);
+
+	p->last_layout = new_lang;
+
+	return TRUE;
+}
+
 static int program_check_lang_last_word(struct _program *p)
 {
 	if (xconfig->handle->languages[get_curr_keyboard_group()].excluded)
@@ -1476,45 +1503,7 @@ static int program_check_lang_last_word(struct _program *p)
 	    (p->buffer->content[p->buffer->cur_pos-1] == 11))   // Tab
 			return FALSE;
 
-	int cur_lang = get_curr_keyboard_group();
-
-	int new_lang = NO_LANGUAGE;
-	if (xconfig->check_similar_words)
-	{
-		new_lang = check_lang_with_similar_words(xconfig->handle, p->buffer, cur_lang);
-	}
-	else
-	{
-		new_lang = check_lang(xconfig->handle, p->buffer, cur_lang);
-	}
-
-	if (new_lang == NO_LANGUAGE)
-	{
-		log_message(DEBUG, _("No language found to change to"));
-		return FALSE;
-	}
-
-	if (new_lang == cur_lang)
-	{
-		return FALSE;
-	}
-
-	int change_action = CHANGE_WORD_TO_LAYOUT_0;
-	if (new_lang == 0)
-		change_action = CHANGE_WORD_TO_LAYOUT_0;
-	else if (new_lang == 1)
-		change_action = CHANGE_WORD_TO_LAYOUT_1;
-	else if (new_lang == 2)
-		change_action = CHANGE_WORD_TO_LAYOUT_2;
-	else
-		change_action = CHANGE_WORD_TO_LAYOUT_3;
-
-	program_change_word(p, change_action);
-	show_notify(NOTIFY_AUTOMATIC_CHANGE_WORD, NULL);
-
-	p->last_layout = new_lang;
-
-	return TRUE;
+	return change(p, CHANGE_WORD_TO_LAYOUT_0, xconfig->check_similar_words);
 }
 
 static int program_check_lang_last_syllable(struct _program *p)
@@ -1535,34 +1524,7 @@ static int program_check_lang_last_syllable(struct _program *p)
 	if (strlen(word) < 3)
 		return FALSE;
 
-	int cur_lang = get_curr_keyboard_group();
-	int new_lang = check_lang(xconfig->handle, p->buffer, cur_lang);
-
-	if (new_lang == NO_LANGUAGE)
-	{
-		log_message(DEBUG, _("No language found to change to"));
-		return FALSE;
-	}
-
-	if (new_lang == cur_lang)
-		return FALSE;
-
-	int change_action = 0;
-	if (new_lang == 0)
-		change_action = CHANGE_SYLL_TO_LAYOUT_0;
-	else if (new_lang == 1)
-		change_action = CHANGE_SYLL_TO_LAYOUT_1;
-	else if (new_lang == 2)
-		change_action = CHANGE_SYLL_TO_LAYOUT_2;
-	else
-		change_action = CHANGE_SYLL_TO_LAYOUT_3;
-
-	program_change_word(p, change_action);
-	show_notify(NOTIFY_AUTOMATIC_CHANGE_WORD, NULL);
-
-	p->last_layout = new_lang;
-
-	return TRUE;
+	return change(p, CHANGE_SYLL_TO_LAYOUT_0, FALSE);
 }
 
 static void program_check_caps_last_word(struct _program *p)
@@ -2509,6 +2471,68 @@ static void program_send_string_silent(struct _program *p, int send_backspaces)
 	p->event->send_string(p->event, p->buffer);		// Send new string
 }
 
+static void correct_word(struct _program *p, KeySym keysym, int keycount, enum _correction_action action)
+{
+	if (p->correction_action == CORRECTION_NONE)
+	{
+		p->event->send_backspaces(p->event, keycount);
+
+		int key_code = main_window->keymap->max_keycode;
+		int size = main_window->keymap->keysyms_per_keycode;
+		KeySym *keymap = main_window->keymap->keymap + (key_code - main_window->keymap->min_keycode) * size;
+
+		// Symbols currently mapped to the `key_code` (key code represents physical key
+		// on the keyboard and keysym -- different symbols on that key, that con be produced
+		// by pressing key or key with some modifiers (Alt, Ctrl, Shift))
+		KeySym keysyms_bckp[size];
+		for (int i = 0; i < size; i++)
+		{
+			keysyms_bckp[i] = keymap[i];
+		}
+
+		KeySym keysyms[size];
+		for (int i = 0; i < size; i++)
+		{
+			keysyms[i] = keysym;
+		}
+		// Associate `key_code` with number of `keysyms`. Actually, key code will be
+		// associated with only one `keysym` for all possible combinations of key + modifiers
+		XChangeKeyboardMapping(main_window->display, key_code, size, keysyms, 1);
+		XFlush(main_window->display);
+		XSync(main_window->display, TRUE);
+
+		p->event->send_xkey(p->event, key_code, 0);
+		usleep(100000);
+
+		// Restore previous association
+		XChangeKeyboardMapping(main_window->display, key_code, size, keysyms_bckp, 1);
+		XFlush(main_window->display);
+		XSync(main_window->display, TRUE);
+
+		p->buffer->clear(p->buffer);
+		p->event->default_event.xkey.keycode = 0;
+	} else
+	if (p->correction_action == action)
+	{
+		p->event->send_spaces(p->event, keycount);
+
+		p->buffer->set_content(p->buffer, p->correction_buffer->get_last_word(p->correction_buffer, p->correction_buffer->content));
+		p->buffer->set_lang_mask(p->buffer, get_curr_keyboard_group ());
+
+		int offset = p->buffer->get_last_word_offset(p->buffer, p->buffer->content, p->buffer->cur_pos);
+
+		// Shift fields to point to begin of word
+		p->buffer->set_offset(p->buffer, offset);
+
+		program_send_string_silent(p, p->buffer->cur_pos);
+
+		// Revert fields back
+		p->buffer->unset_offset(p->buffer, offset);
+
+		p->correction_buffer->clear(p->correction_buffer);
+		p->correction_action = CORRECTION_NONE;
+	}
+}
 static void program_change_word(struct _program *p, enum _change_action action)
 {
 	switch (action)
@@ -2690,293 +2714,27 @@ static void program_change_word(struct _program *p, enum _change_action action)
 		}
 		case CHANGE_COPYRIGHT:
 		{
-			if (p->correction_action == CORRECTION_NONE)
-			{
-				p->event->send_backspaces(p->event, 2);
-
-				int key_code = main_window->keymap->max_keycode;
-				KeySym keysyms_bckp[main_window->keymap->keysyms_per_keycode];
-				KeySym *keymap = main_window->keymap->keymap + (key_code - main_window->keymap->min_keycode) * main_window->keymap->keysyms_per_keycode;
-				for (int i = 0; i < main_window->keymap->keysyms_per_keycode; i++)
-				{
-					keysyms_bckp[i]= keymap[i];
-				}
-
-				KeySym keysyms[main_window->keymap->keysyms_per_keycode];
-
-				for (int i = 0; i < main_window->keymap->keysyms_per_keycode; i++)
-				{
-					keysyms[i]= XK_copyright;//
-				}
-				XChangeKeyboardMapping(main_window->display, key_code,
-								        main_window->keymap->keysyms_per_keycode, keysyms, 1);
-				XFlush(main_window->display);
-				XSync(main_window->display, TRUE);
-				p->event->send_xkey(p->event, key_code, 0);
-				usleep(100000);
-
-				XChangeKeyboardMapping(main_window->display, key_code,
-			   		                    main_window->keymap->keysyms_per_keycode, keysyms_bckp, 1);
-				XFlush(main_window->display);
-				XSync(main_window->display, TRUE);
-
-				p->buffer->clear(p->buffer);
-				p->event->default_event.xkey.keycode = 0;
-			}
-			else if (p->correction_action == CORRECTION_COPYRIGHT)
-			{
-				p->event->send_spaces(p->event, 2);
-
-				p->buffer->set_content(p->buffer, p->correction_buffer->get_last_word(p->correction_buffer, p->correction_buffer->content));
-				p->buffer->set_lang_mask(p->buffer, get_curr_keyboard_group ());
-
-				int offset = p->buffer->get_last_word_offset(p->buffer, p->buffer->content, p->buffer->cur_pos);
-
-				// Shift fields to point to begin of word
-				p->buffer->set_offset(p->buffer, offset);
-
-				program_send_string_silent(p, p->buffer->cur_pos);
-
-				// Revert fields back
-				p->buffer->unset_offset(p->buffer, offset);
-
-				p->correction_buffer->clear(p->correction_buffer);
-				p->correction_action = CORRECTION_NONE;
-			}
+			correct_word(p, XK_copyright, 2, CORRECTION_COPYRIGHT);
 			break;
 		}
 		case CHANGE_TRADEMARK:
 		{
-			if (p->correction_action == CORRECTION_NONE)
-			{
-				p->event->send_backspaces(p->event, 3);
-
-				int key_code = main_window->keymap->max_keycode;
-				KeySym keysyms_bckp[main_window->keymap->keysyms_per_keycode];
-				KeySym *keymap = main_window->keymap->keymap + (key_code - main_window->keymap->min_keycode) * main_window->keymap->keysyms_per_keycode;
-				for (int i = 0; i < main_window->keymap->keysyms_per_keycode; i++)
-				{
-					keysyms_bckp[i]= keymap[i];
-				}
-
-				KeySym keysyms[main_window->keymap->keysyms_per_keycode];
-
-				for (int i = 0; i < main_window->keymap->keysyms_per_keycode; i++)
-				{
-					keysyms[i]= XK_trademark;//
-				}
-				XChangeKeyboardMapping(main_window->display, key_code,
-								        main_window->keymap->keysyms_per_keycode, keysyms, 1);
-				XFlush(main_window->display);
-				XSync(main_window->display, TRUE);
-				p->event->send_xkey(p->event, key_code, 0);
-				usleep(100000);
-
-				XChangeKeyboardMapping(main_window->display, key_code,
-			   		                    main_window->keymap->keysyms_per_keycode, keysyms_bckp, 1);
-				XFlush(main_window->display);
-				XSync(main_window->display, TRUE);
-
-				p->buffer->clear(p->buffer);
-				p->event->default_event.xkey.keycode = 0;
-			}
-			else if (p->correction_action == CORRECTION_TRADEMARK)
-			{
-				p->event->send_spaces(p->event, 3);
-
-				p->buffer->set_content(p->buffer, p->correction_buffer->get_last_word(p->correction_buffer, p->correction_buffer->content));
-				p->buffer->set_lang_mask(p->buffer, get_curr_keyboard_group ());
-
-				int offset = p->buffer->get_last_word_offset(p->buffer, p->buffer->content, p->buffer->cur_pos);
-
-				// Shift fields to point to begin of word
-				p->buffer->set_offset(p->buffer, offset);
-
-				program_send_string_silent(p, p->buffer->cur_pos);
-
-				// Revert fields back
-				p->buffer->unset_offset(p->buffer, offset);
-
-				p->correction_buffer->clear(p->correction_buffer);
-				p->correction_action = CORRECTION_NONE;
-			}
+			correct_word(p, XK_trademark, 3, CORRECTION_TRADEMARK);
 			break;
 		}
 		case CHANGE_REGISTERED:
 		{
-			if (p->correction_action == CORRECTION_NONE)
-			{
-				p->event->send_backspaces(p->event, 2);
-
-				int key_code = main_window->keymap->max_keycode;
-				KeySym keysyms_bckp[main_window->keymap->keysyms_per_keycode];
-				KeySym *keymap = main_window->keymap->keymap + (key_code - main_window->keymap->min_keycode) * main_window->keymap->keysyms_per_keycode;
-				for (int i = 0; i < main_window->keymap->keysyms_per_keycode; i++)
-				{
-					keysyms_bckp[i]= keymap[i];
-				}
-
-				KeySym keysyms[main_window->keymap->keysyms_per_keycode];
-
-				for (int i = 0; i < main_window->keymap->keysyms_per_keycode; i++)
-				{
-					keysyms[i]= XK_registered;//
-				}
-				XChangeKeyboardMapping(main_window->display, key_code,
-								        main_window->keymap->keysyms_per_keycode, keysyms, 1);
-				XFlush(main_window->display);
-				XSync(main_window->display, TRUE);
-				p->event->send_xkey(p->event, key_code, 0);
-				usleep(100000);
-
-				XChangeKeyboardMapping(main_window->display, key_code,
-			   		                    main_window->keymap->keysyms_per_keycode, keysyms_bckp, 1);
-				XFlush(main_window->display);
-				XSync(main_window->display, TRUE);
-
-				p->buffer->clear(p->buffer);
-				p->event->default_event.xkey.keycode = 0;
-			}
-			else if (p->correction_action == CORRECTION_REGISTERED)
-			{
-				p->event->send_spaces(p->event, 2);
-
-				p->buffer->set_content(p->buffer, p->correction_buffer->get_last_word(p->correction_buffer, p->correction_buffer->content));
-				p->buffer->set_lang_mask(p->buffer, get_curr_keyboard_group ());
-
-				int offset = p->buffer->get_last_word_offset(p->buffer, p->buffer->content, p->buffer->cur_pos);
-
-				// Shift fields to point to begin of word
-				p->buffer->set_offset(p->buffer, offset);
-
-				program_send_string_silent(p, p->buffer->cur_pos);
-
-				// Revert fields back
-				p->buffer->unset_offset(p->buffer, offset);
-
-				p->correction_buffer->clear(p->correction_buffer);
-				p->correction_action = CORRECTION_NONE;
-			}
+			correct_word(p, XK_registered, 2, CORRECTION_REGISTERED);
 			break;
 		}
 		case CHANGE_ELLIPSIS:
 		{
-			if (p->correction_action == CORRECTION_NONE)
-			{
-				p->event->send_backspaces(p->event, 2);
-
-				int key_code = main_window->keymap->max_keycode;
-				KeySym keysyms_bckp[main_window->keymap->keysyms_per_keycode];
-				KeySym *keymap = main_window->keymap->keymap + (key_code - main_window->keymap->min_keycode) * main_window->keymap->keysyms_per_keycode;
-				for (int i = 0; i < main_window->keymap->keysyms_per_keycode; i++)
-				{
-					keysyms_bckp[i]= keymap[i];
-				}
-
-				KeySym keysyms[main_window->keymap->keysyms_per_keycode];
-
-				for (int i = 0; i < main_window->keymap->keysyms_per_keycode; i++)
-				{
-					keysyms[i]= XK_ellipsis;//
-				}
-				XChangeKeyboardMapping(main_window->display, key_code,
-								        main_window->keymap->keysyms_per_keycode, keysyms, 1);
-				XFlush(main_window->display);
-				XSync(main_window->display, TRUE);
-				p->event->send_xkey(p->event, key_code, 0);
-				usleep(100000);
-
-				XChangeKeyboardMapping(main_window->display, key_code,
-			   		                    main_window->keymap->keysyms_per_keycode, keysyms_bckp, 1);
-				XFlush(main_window->display);
-				XSync(main_window->display, TRUE);
-
-				p->buffer->clear(p->buffer);
-				p->correction_buffer->clear(p->buffer);
-				p->event->default_event.xkey.keycode = 0;
-			}
-			else if (p->correction_action == CORRECTION_ELLIPSIS)
-			{
-				p->event->send_spaces(p->event, 2);
-
-				p->buffer->set_content(p->buffer, p->correction_buffer->get_last_word(p->correction_buffer, p->correction_buffer->content));
-				p->buffer->set_lang_mask(p->buffer, get_curr_keyboard_group ());
-
-				int offset = p->buffer->get_last_word_offset(p->buffer, p->buffer->content, p->buffer->cur_pos);
-
-				// Shift fields to point to begin of word
-				p->buffer->set_offset(p->buffer, offset);
-
-				program_send_string_silent(p, p->buffer->cur_pos);
-
-				// Revert fields back
-				p->buffer->unset_offset(p->buffer, offset);
-
-				p->correction_buffer->clear(p->correction_buffer);
-				p->correction_action = CORRECTION_NONE;
-			}
+			correct_word(p, XK_ellipsis, 2, CORRECTION_ELLIPSIS);
 			break;
 		}
 		case CHANGE_WORD_TO_LAYOUT_0:
-		{
-			int offset = p->buffer->get_last_word_offset(p->buffer, p->buffer->content, p->buffer->cur_pos);
-
-			// Shift fields to point to begin of word
-			p->buffer->set_offset(p->buffer, offset);
-
-			program_change_lang(p, 0);
-
-			int len = p->buffer->cur_pos;
-			if (p->last_action == ACTION_AUTOCOMPLETION)
-				len = p->buffer->cur_pos + 1;
-			program_send_string_silent(p, len);
-
-			p->last_action = ACTION_NONE;
-
-			// Revert fields back
-			p->buffer->unset_offset(p->buffer, offset);
-			break;
-		}
 		case CHANGE_WORD_TO_LAYOUT_1:
-		{
-			int offset = p->buffer->get_last_word_offset(p->buffer, p->buffer->content, p->buffer->cur_pos);
-
-			// Shift fields to point to begin of word
-			p->buffer->set_offset(p->buffer, offset);
-
-			program_change_lang(p, 1);
-
-			int len = p->buffer->cur_pos;
-			if (p->last_action == ACTION_AUTOCOMPLETION)
-				len = p->buffer->cur_pos + 1;
-			program_send_string_silent(p, len);
-
-			p->last_action = ACTION_NONE;
-
-			// Revert fields back
-			p->buffer->unset_offset(p->buffer, offset);
-			break;
-		}
 		case CHANGE_WORD_TO_LAYOUT_2:
-		{
-			int offset = p->buffer->get_last_word_offset(p->buffer, p->buffer->content, p->buffer->cur_pos);
-
-			// Shift fields to point to begin of word
-			p->buffer->set_offset(p->buffer, offset);
-
-			program_change_lang(p, 2);
-
-			int len = p->buffer->cur_pos;
-			if (p->last_action == ACTION_AUTOCOMPLETION)
-				len = p->buffer->cur_pos + 1;
-			program_send_string_silent(p, len);
-
-			p->last_action = ACTION_NONE;
-
-			// Revert fields back
-			p->buffer->unset_offset(p->buffer, offset);
-			break;
-		}
 		case CHANGE_WORD_TO_LAYOUT_3:
 		{
 			int offset = p->buffer->get_last_word_offset(p->buffer, p->buffer->content, p->buffer->cur_pos);
@@ -2984,7 +2742,7 @@ static void program_change_word(struct _program *p, enum _change_action action)
 			// Shift fields to point to begin of word
 			p->buffer->set_offset(p->buffer, offset);
 
-			program_change_lang(p, 3);
+			program_change_lang(p, action - CHANGE_WORD_TO_LAYOUT_0);
 
 			int len = p->buffer->cur_pos;
 			if (p->last_action == ACTION_AUTOCOMPLETION)
@@ -3061,59 +2819,8 @@ static void program_change_word(struct _program *p, enum _change_action action)
 			break;
 		}
 		case CHANGE_SYLL_TO_LAYOUT_0:
-		{
-			int offset = p->buffer->get_last_word_offset(p->buffer, p->buffer->content, p->buffer->cur_pos);
-
-			// Shift fields to point to begin of word
-			p->buffer->set_offset(p->buffer, offset);
-
-			program_change_lang(p, 0);
-
-			int len = p->buffer->cur_pos - 1;
-			if (p->last_action == ACTION_AUTOCOMPLETION)
-				len = p->buffer->cur_pos;
-			program_send_string_silent(p, len);
-
-			// Revert fields back
-			p->buffer->unset_offset(p->buffer, offset);
-			break;
-		}
 		case CHANGE_SYLL_TO_LAYOUT_1:
-		{
-			int offset = p->buffer->get_last_word_offset(p->buffer, p->buffer->content, p->buffer->cur_pos);
-
-			// Shift fields to point to begin of word
-			p->buffer->set_offset(p->buffer, offset);
-
-			program_change_lang(p, 1);
-
-			int len = p->buffer->cur_pos - 1;
-			if (p->last_action == ACTION_AUTOCOMPLETION)
-				len = p->buffer->cur_pos;
-			program_send_string_silent(p, len);
-
-			// Revert fields back
-			p->buffer->unset_offset(p->buffer, offset);
-			break;
-		}
 		case CHANGE_SYLL_TO_LAYOUT_2:
-		{
-			int offset = p->buffer->get_last_word_offset(p->buffer, p->buffer->content, p->buffer->cur_pos);
-
-			// Shift fields to point to begin of word
-			p->buffer->set_offset(p->buffer, offset);
-
-			program_change_lang(p, 2);
-
-			int len = p->buffer->cur_pos - 1;
-			if (p->last_action == ACTION_AUTOCOMPLETION)
-				len = p->buffer->cur_pos;
-			program_send_string_silent(p, len);
-
-			// Revert fields back
-			p->buffer->unset_offset(p->buffer, offset);
-			break;
-		}
 		case CHANGE_SYLL_TO_LAYOUT_3:
 		{
 			int offset = p->buffer->get_last_word_offset(p->buffer, p->buffer->content, p->buffer->cur_pos);
@@ -3121,7 +2828,7 @@ static void program_change_word(struct _program *p, enum _change_action action)
 			// Shift fields to point to begin of word
 			p->buffer->set_offset(p->buffer, offset);
 
-			program_change_lang(p, 3);
+			program_change_lang(p, action - CHANGE_SYLL_TO_LAYOUT_0);
 
 			int len = p->buffer->cur_pos - 1;
 			if (p->last_action == ACTION_AUTOCOMPLETION)
@@ -3138,32 +2845,11 @@ static void program_change_word(struct _program *p, enum _change_action action)
 			break;
 		}
 		case CHANGE_STRING_TO_LAYOUT_0:
-		{
-			program_change_lang(p, 0);
-			//p->focus->update_events(p->focus, LISTEN_DONTGRAB_INPUT);	// Disable receiving events
-
-			program_send_string_silent(p, p->buffer->cur_pos);
-			break;
-		}
 		case CHANGE_STRING_TO_LAYOUT_1:
-		{
-			program_change_lang(p, 1);
-			//p->focus->update_events(p->focus, LISTEN_DONTGRAB_INPUT);	// Disable receiving events
-
-			program_send_string_silent(p, p->buffer->cur_pos);
-			break;
-		}
 		case CHANGE_STRING_TO_LAYOUT_2:
-		{
-			program_change_lang(p, 2);
-			//p->focus->update_events(p->focus, LISTEN_DONTGRAB_INPUT);	// Disable receiving events
-
-			program_send_string_silent(p, p->buffer->cur_pos);
-			break;
-		}
 		case CHANGE_STRING_TO_LAYOUT_3:
 		{
-			program_change_lang(p, 3);
+			program_change_lang(p, action - CHANGE_STRING_TO_LAYOUT_0);
 			//p->focus->update_events(p->focus, LISTEN_DONTGRAB_INPUT);	// Disable receiving events
 
 			program_send_string_silent(p, p->buffer->cur_pos);

--- a/xneur/lib/main/program.c
+++ b/xneur/lib/main/program.c
@@ -518,7 +518,7 @@ static void program_process_input(struct _program *p)
 										  (Window)p->focus->owner_window,
 										  &wDummy, &wDummy, &iDummy, &iDummy, &iDummy, &iDummy,
 										  &mask);
-							mask = mask & (~get_languages_mask ());
+							mask = mask & get_languages_mask();
 							log_message(TRACE, _("Received XI_KeyPress '%s' == %u (event type %d)"),
 										XKeysymToString(key_sym),
 										xi_event->detail,
@@ -542,7 +542,7 @@ static void program_process_input(struct _program *p)
 										  (Window)p->focus->owner_window,
 										  &wDummy, &wDummy, &iDummy, &iDummy, &iDummy, &iDummy,
 										  &mask);
-							mask = mask & (~get_languages_mask ());
+							mask = mask & get_languages_mask();
 							log_message(TRACE, _("Received XI_KeyRelease '%s'== %u (event type %d)"),
 										XKeysymToString(key_sym),
 										xi_event->detail,
@@ -587,7 +587,7 @@ static void program_process_input(struct _program *p)
 									  (Window)p->focus->owner_window,
 									  &wDummy, &wDummy, &iDummy, &iDummy, &iDummy, &iDummy,
 									  &mask);
-						mask = mask & (~get_languages_mask ());
+						mask = mask & get_languages_mask();
 						log_message(TRACE, _("Received KeyPress '%s' == %u (event type %d)"),
 									XKeysymToString(key_sym),
 									p->event->event.xkey.keycode,
@@ -615,7 +615,7 @@ static void program_process_input(struct _program *p)
 									  (Window)p->focus->owner_window,
 									  &wDummy, &wDummy, &iDummy, &iDummy, &iDummy, &iDummy,
 									  &mask);
-						mask = mask & (~get_languages_mask ());
+						mask = mask & get_languages_mask();
 						log_message(TRACE, _("Received KeyRelease '%s' == %u (event type %d)"),
 									XKeysymToString(key_sym),
 									p->event->event.xkey.keycode,

--- a/xneur/lib/main/program.c
+++ b/xneur/lib/main/program.c
@@ -3193,17 +3193,15 @@ static void program_uninit(struct _program *p)
 
 struct _program* program_init(void)
 {
-	struct _program *p = (struct _program*) malloc(sizeof(struct _program));
-	memset(p, 0, sizeof(struct _program));
-
 	main_window = window_init(xconfig->handle);
 
 	if (!main_window->create(main_window) || !main_window->init_keymap(main_window))
 	{
-		if (p != NULL)
-			free(p);
 		return NULL;
 	}
+
+	struct _program *p = (struct _program*) malloc(sizeof(struct _program));
+	memset(p, 0, sizeof(struct _program));
 
 	int event = 0;
 	int error = 0;


### PR DESCRIPTION
76bda41 -- из diff-а не совсем очевидно, что произошло выделение 2-х повтряющихся кусков кода в 2 функции. В целом:
- `program_check_lang_last_word` и `program_check_lang_last_syllable` теперь используют общий код из функции `change`
- `program_change_word` вызывает вспомогательную функцию `correct_word` для обработки коррекций всякой типографики:
  - символ копирайта
  - символ торговой марки
  - символ зарегистрированного товарного знака
  - символ троеточия
- в `program_change_word` смена раскладки последнего слова и последнего предложения теперь обрабатываются одной копией кода для всех 4-х лайоутов

В 4b89c86 сделано прямое использование структуры `XKeyEvent` вместо более общей `XEvent`, которая является enum-ом, включающем в том числе и `XKeyEvent`

В e0263a8 замечено, что результат `get_languages_mask` всегда используется с оператором `~`, поэтому сразу возвращаем такой результат из функции.

В 6ea340a удалена ненужная проверка на `null`, так как вызываемая локальная для файла функция никогда его не возвращает.

Наконец, в 33cf40c и 2888a13 выделение памяти под структуры делается уже после того, как все проверки были сделаны, что читается проще, чем сначала выделить память, а потом не забывать ее очищать, если проверки будут неуспешны.