### PR TITLE
Revert ""strncat -> memmove" patch"

### DIFF
--- a/xneur/lib/lib/xneurlib.c
+++ b/xneur/lib/lib/xneurlib.c
@@ -361,9 +361,9 @@ struct _xneur_handle *xneur_handle_create (void)
 			if (dict_name == NULL)
 				continue;
 			dict_name[0] = NULLSYM;
-			memmove(dict_name, spell_names[j], len1);
-			memmove(dict_name, "_", 1);
-			memmove(dict_name, handle->languages[lang].dir, len2);
+			strncat(dict_name, spell_names[j], len1);
+			strncat(dict_name, "_", 1);
+			strncat(dict_name, handle->languages[lang].dir, len2);
 			dict_name[3] = toupper(dict_name[3]);
 			dict_name[4] = toupper(dict_name[4]);
 			//printf("   [!] Try load dict %s\n", dict_name);

--- a/xneur/lib/main/bind_table.c
+++ b/xneur/lib/main/bind_table.c
@@ -66,11 +66,11 @@ static char* hotkey_concat_bind(struct _xneur_hotkey * hotkey)
 		if ((hotkey->modifiers & (0x1 << i)) == 0)
 			continue;
 
-		memmove(text, modifier_names[i], sizeof(modifier_names[i])-1);// number of symbols minus trailing zero
-		memmove(text, "+", 1);
+		strncat(text, modifier_names[i], sizeof(modifier_names[i])-1);// number of symbols minus trailing zero
+		strncat(text, "+", 1);
 	}
 
-	memmove(text, hotkey->key, len);
+	strncat(text, hotkey->key, len);
 
 	return text;
 }

--- a/xneur/lib/main/buffer.c
+++ b/xneur/lib/main/buffer.c
@@ -381,12 +381,12 @@ static void append_to_i18n_content(struct _buffer *buf, int pos, int languages_m
 		size_t len = strlen(symbol);
 		void *tmp = realloc(p->content, (strlen(p->content) + len + 1) * sizeof(char));
 		assert(tmp != NULL);
-		p->content = memmove((char *)tmp, symbol, len);
+		p->content = strncat((char *)tmp, symbol, len);
 
 		size_t len_unchanged = strlen(symbol_unchanged);
 		tmp = realloc(p->content_unchanged, (strlen(p->content_unchanged) + len_unchanged + 1) * sizeof(char));
 		assert(tmp != NULL);
-		p->content_unchanged = memmove((char *)tmp, symbol_unchanged, len_unchanged);
+		p->content_unchanged = strncat((char *)tmp, symbol_unchanged, len_unchanged);
 
 		tmp = realloc(p->symbol_len, (pos + 1) * sizeof(int));
 		assert(tmp != NULL);
@@ -573,7 +573,7 @@ static char *buffer_get_utf_string(struct _buffer *p)
 		if (tmp != NULL)
 		{
 			utf_string = tmp;
-			memmove(utf_string, symbol, nbytes);
+			strncat(utf_string, symbol, nbytes);
 		}
 	}
 
@@ -604,7 +604,7 @@ static char *buffer_get_utf_string_on_kbd_group(struct _buffer *p, int group)
 			if (tmp != NULL)
 			{
 				utf_string = tmp;
-				memmove(utf_string, symbol, len);
+				strncat(utf_string, symbol, len);
 			}
 			free(symbol);
 		}
@@ -646,7 +646,7 @@ int buffer_get_last_word_offset(struct _buffer *p, const char *string, int strin
 		{
 			char *symbol = p->keymap->keycode_to_symbol(p->keymap, XKeysymToKeycode(p->keymap->display, xconfig->delimeters[i]), -1, 0);
 			if (strlen(symbol) == 1)
-				memmove(xconfig->delimeters_string, symbol, 1);
+				strncat(xconfig->delimeters_string, symbol, 1);
 			free(symbol);
 		}
 		//log_message (DEBUG,"'%s'", xconfig->delimeters_string);

--- a/xneur/lib/main/keymap.c
+++ b/xneur/lib/main/keymap.c
@@ -133,7 +133,7 @@ static char* keymap_keycode_to_symbol_real(struct _keymap *p, KeyCode kc, int gr
 		log_message(ERROR, _("Failed to look up symbol for keycode %d and modifier 0x%x!"), event.keycode, event.state);
 		log_message(ERROR, _("Try run the program with command \"env LC_ALL=<LOCALE> %s\", \nwhere LOCALE available over command \"locale -a\""), PACKAGE);
 		symbol[0] = NULLSYM;
-		memmove(symbol, " ", 1);
+		strncat(symbol, " ", 1);
 
 		locales->uninit(locales);
 
@@ -296,7 +296,7 @@ static char keymap_get_ascii_real(struct _keymap *p, const char *sym, int* prefe
 							continue;
 
 						size_t _symbol_len = strlen(symbol);
-						memmove(prev_symbols, symbol, avail_space);
+						strncat(prev_symbols, symbol, avail_space);
 						avail_space -= _symbol_len;
 
 						if (strncmp(sym, symbol, _symbol_len) != 0)

--- a/xneur/lib/main/program.c
+++ b/xneur/lib/main/program.c
@@ -2395,8 +2395,8 @@ static void program_check_misprint(struct _program *p)
 		int possible_word_len = strlen(possible_word);
 		char *new_content = malloc((new_offset + possible_word_len + backspaces_count + 1) * sizeof(char));
 		memset(new_content, 0, (new_offset + possible_word_len + backspaces_count + 1) * sizeof(char));
-		new_content = memmove(new_content, p->buffer->content, new_offset);
-		new_content = memmove(new_content, possible_word, possible_word_len);
+		new_content = strncat(new_content, p->buffer->content, new_offset);
+		new_content = strncat(new_content, possible_word, possible_word_len);
 		// после исправления опечатки, добавляем запятые и прочее, идущее после слова >>>
 		size_t size = 0;
 		const char* content_unchanged = p->correction_buffer->i18n_content[lang].content_unchanged;
@@ -2422,7 +2422,7 @@ static void program_check_misprint(struct _program *p)
 		//   "a," => size=1, append ","
 		//   ",a" => size=0, append ""
 		//   "aa" => size=0, append ""
-		new_content = memmove(new_content, content_unchanged + len_unchanged - size, size);
+		new_content = strncat(new_content, content_unchanged + len_unchanged - size, size);
 		// <<<
 
 		p->buffer->set_content(p->buffer, new_content);

--- a/xneur/lib/misc/list_char.c
+++ b/xneur/lib/misc/list_char.c
@@ -132,12 +132,12 @@ static int find_id(struct _list_char *list, const char *string, int mode)
 		{
 			struct _list_char_data *data = &list->data[i];
 			//data = &list->data[i];
-			memmove(full_str, data->string, strlen(data->string));
-			memmove(full_str, "|", 1);
+			strncat(full_str, data->string, strlen(data->string));
+			strncat(full_str, "|", 1);
 		}
 
 		struct _list_char_data *data = &list->data[list->data_count - 1];
-		memmove(full_str, data->string, strlen(data->string));
+		strncat(full_str, data->string, strlen(data->string));
 
 		if (check_regexp_match(string, full_str))
 		{

--- a/xneur/lib/misc/text.c
+++ b/xneur/lib/misc/text.c
@@ -142,18 +142,18 @@ char* str_replace(const char *source, const char *search, const char *replace)
 		char *found = strstr(source, search);
 		if (found == NULL)
 		{
-			memmove(result, source, avail_space);
+			strncat(result, source, avail_space);
 			break;
 		}
 
 		// Copy to result all data from source to found
 		if (found != source) {
 			size_t len = found - source;
-			memmove(result, source, len);
+			strncat(result, source, len);
 			avail_space -= len;
 		}
 
-		memmove(result, replace, avail_space);
+		strncat(result, replace, avail_space);
 		source = found + search_len;
 		avail_space -= replace_len;
 	}

--- a/xneur/lib/notify/osd.c
+++ b/xneur/lib/notify/osd.c
@@ -81,7 +81,7 @@ void osd_show(int notify, char *command)
 		char *tmp = realloc(osd_text, (strlen(osd_text) + len + 1) * sizeof(char));
 		if (tmp != NULL)
 		{
-			osd_text = memmove(tmp, xconfig->osds[notify].file, len);
+			osd_text = strncat(tmp, xconfig->osds[notify].file, len);
 		}
 	}
 	if (command != NULL)
@@ -91,8 +91,8 @@ void osd_show(int notify, char *command)
 		if (tmp != NULL)
 		{
 			osd_text = tmp;
-			osd_text = memmove(osd_text, " ", 1);
-			osd_text = memmove(osd_text, command, len);
+			osd_text = strncat(osd_text, " ", 1);
+			osd_text = strncat(osd_text, command, len);
 		}
 	}
 	//


### PR DESCRIPTION
Как отмечено в https://github.com/AndrewCrewKuznetsov/xneur-devel/commit/06d3a6cc6d85fa0251e044a951bf8f28dc4b2f2c#comments, замена `strncat` на `memmove` не является корректной:
1. Во-первых, [`memmove`] может заменять [`strncpy`], а не [`strncat`]
2. Во-вторых, [`strncat`] копирует `<=n` символов, до первого нулевого символа, а [`memmove`] -- ровно `n`. В нашем случае от такой замены ничего плохого нет, т.к. `n` всегда равно длине строки до первого `\0`.
3. В-третьих, [`strncat`] добавляет к строке завершающий ноль помимо `<=n` скопированных символов, а [`memmove`] этого не делает. Во подавляющем числе случаев использования [`strncat`] после выделения память она не зануляется, таким образом нет гарантии, что после таких замен останется нулевой символ в конце строки.

[`memmove`]: http://www.cplusplus.com/reference/cstring/memmove/
[`strncpy`]: http://www.cplusplus.com/reference/cstring/strncpy/
[`strncat`]: http://www.cplusplus.com/reference/cstring/strncat/
