### PR TITLE
Исправление некоторых проблем с памятью и сопуствующий рефакторинг

### DIFF
--- a/xneur/lib/main/buffer.c
+++ b/xneur/lib/main/buffer.c
@@ -52,8 +52,6 @@
 
 #define INIT_STRING_LENGTH 64
 
-static const int keyboard_groups[]	= {0x00000000, 0x00002000, 0x00004000, 0x00006000};
-
 extern struct _xneur_config *xconfig;
 
 Window last_log_window = 0;
@@ -594,7 +592,7 @@ static char *buffer_get_utf_string_on_kbd_group(struct _buffer *p, int group)
 		int state = p->keycode_modifiers[i];
 		for (int j = 0; j < p->handle->total_languages; j++)
 		{
-			state = state & (~keyboard_groups[j]);
+			state = state & (~get_keycode_mod(j));
 		}
 		char *symbol = p->keymap->keycode_to_symbol(p->keymap, p->keycode[i], group, state);
 		if (symbol != NULL)

--- a/xneur/lib/main/focus.c
+++ b/xneur/lib/main/focus.c
@@ -75,13 +75,11 @@ static int get_focus(struct _focus *p, int *forced_mode, int *focus_status, int 
 		// dont process modifier keys (see utils.h)
 		/*if (main_window->_NET_SUPPORTED)
 		{
-			Atom type;
-			int size;
-			long nitems;
+			unsigned long nitems;
 
 			Atom request = XInternAtom(main_window->display, "_NET_ACTIVE_WINDOW", False);
 			Window root = XDefaultRootWindow(main_window->display);
-			unsigned char *data = get_win_prop(root, request, &nitems, &type, &size);
+			unsigned char *data = get_win_prop(root, request, &nitems);
 
 			if (nitems > 0)
 				new_window = *((Window*)data);

--- a/xneur/lib/main/focus.c
+++ b/xneur/lib/main/focus.c
@@ -79,7 +79,7 @@ static int get_focus(struct _focus *p, int *forced_mode, int *focus_status, int 
 
 			Atom request = XInternAtom(main_window->display, "_NET_ACTIVE_WINDOW", False);
 			Window root = XDefaultRootWindow(main_window->display);
-			unsigned char *data = get_win_prop(root, request, &nitems);
+			unsigned char *data = get_win_prop(main_window->display, root, request, &nitems);
 
 			if (nitems > 0)
 				new_window = *((Window*)data);

--- a/xneur/lib/main/program.c
+++ b/xneur/lib/main/program.c
@@ -418,12 +418,14 @@ static void program_process_input(struct _program *p)
 				p->buffer->uninit(p->buffer);
 				p->correction_buffer->uninit(p->correction_buffer);
 
-				main_window->uninit_keymap(main_window);
+				if (main_window->keymap) {//TODO: may be check is unnecessary... but this need check
+					main_window->keymap->uninit(main_window->keymap);
+				}
 
 				xneur_handle_destroy(xconfig->handle);
 				xconfig->handle = xneur_handle_create();
 
-				main_window->init_keymap(main_window);
+				main_window->keymap = keymap_init(xconfig->handle, main_window->display);
 				p->buffer = buffer_init(xconfig->handle, main_window->keymap);
 
 				p->correction_buffer = buffer_init(xconfig->handle, main_window->keymap);
@@ -3195,7 +3197,7 @@ struct _program* program_init(void)
 {
 	main_window = window_init(xconfig->handle);
 
-	if (!main_window->create(main_window) || !main_window->init_keymap(main_window))
+	if (main_window == NULL)
 	{
 		return NULL;
 	}

--- a/xneur/lib/main/utils.c
+++ b/xneur/lib/main/utils.c
@@ -171,26 +171,21 @@ void grab_all_keys(Window window, int is_grab)
 	XSelectInput(main_window->display, window, FOCUS_CHANGE_MASK);
 }
 
-unsigned char *get_win_prop(Window window, Atom atom, long *nitems, Atom *type, int *size)
+unsigned char *get_win_prop(Window window, Atom atom, unsigned long *nitems)
 {
 	Atom actual_type;
 	int actual_format;
-	unsigned long _nitems;
 	unsigned long bytes_after; /* unused */
 	unsigned char *prop;
 	int status;
 
 	status = XGetWindowProperty(main_window->display, window, atom, 0, (~0L),
-                              FALSE, AnyPropertyType, &actual_type,
-                              &actual_format, &_nitems, &bytes_after,
-                              &prop);
+	                            False, AnyPropertyType, &actual_type,
+	                            &actual_format, nitems, &bytes_after,
+	                            &prop);
 	if (status != Success)
 		return NULL;
 
-
-	*nitems = _nitems;
-	*type = actual_type;
-	*size = actual_format;
 	return prop;
 }
 
@@ -208,12 +203,10 @@ char* get_wm_class_name(Window window)
 		if (named_window == None)
 			return NULL;
 
-		Atom type;
-		int size;
-		long nitems;
+		unsigned long nitems;
 
 		Atom request = XInternAtom(main_window->display, "WM_NAME", False);
-		unsigned char *data = get_win_prop(named_window, request, &nitems, &type, &size);
+		unsigned char *data = get_win_prop(named_window, request, &nitems);
 
 		if (nitems > 0)
 			return (char *)data;

--- a/xneur/lib/main/utils.c
+++ b/xneur/lib/main/utils.c
@@ -208,8 +208,13 @@ char* get_wm_class_name(Window window)
 		Atom request = XInternAtom(main_window->display, "WM_NAME", False);
 		unsigned char *data = get_win_prop(named_window, request, &nitems);
 
-		if (nitems > 0)
-			return (char *)data;
+		if (nitems > 0 && data != NULL) {
+			// Returned string is freed by `free` function, but result from `get_win_prop` must be freed by `XFree` function
+			// so just make copy
+			char* result = strdup((char *)data);
+			XFree(data);
+			return result;
+		}
 
 		return NULL;
 	}

--- a/xneur/lib/main/utils.c
+++ b/xneur/lib/main/utils.c
@@ -171,7 +171,7 @@ void grab_all_keys(Window window, int is_grab)
 	XSelectInput(main_window->display, window, FOCUS_CHANGE_MASK);
 }
 
-unsigned char *get_win_prop(Window window, Atom atom, unsigned long *nitems)
+unsigned char *get_win_prop(Display *display, Window window, Atom atom, unsigned long *nitems)
 {
 	Atom actual_type;
 	int actual_format;
@@ -179,7 +179,7 @@ unsigned char *get_win_prop(Window window, Atom atom, unsigned long *nitems)
 	unsigned char *prop;
 	int status;
 
-	status = XGetWindowProperty(main_window->display, window, atom, 0, (~0L),
+	status = XGetWindowProperty(display, window, atom, 0, (~0L),
 	                            False, AnyPropertyType, &actual_type,
 	                            &actual_format, nitems, &bytes_after,
 	                            &prop);
@@ -206,7 +206,7 @@ char* get_wm_class_name(Window window)
 		unsigned long nitems;
 
 		Atom request = XInternAtom(main_window->display, "WM_NAME", False);
-		unsigned char *data = get_win_prop(named_window, request, &nitems);
+		unsigned char *data = get_win_prop(main_window->display, named_window, request, &nitems);
 
 		if (nitems > 0 && data != NULL) {
 			// Returned string is freed by `free` function, but result from `get_win_prop` must be freed by `XFree` function

--- a/xneur/lib/main/utils.h
+++ b/xneur/lib/main/utils.h
@@ -28,7 +28,7 @@ Bool is_modifier(KeySym key_sym);
 char*  get_wm_class_name(Window window);
 void   grab_button(int is_grab);
 void   grab_all_keys(Window window, int is_grab);
-unsigned char *get_win_prop(Window window, Atom atom, unsigned long *nitems);
+unsigned char *get_win_prop(Display *display, Window window, Atom atom, unsigned long *nitems);
 void toggle_lock(int mask, int state);
 void click_key(KeySym keysym);
 

--- a/xneur/lib/main/utils.h
+++ b/xneur/lib/main/utils.h
@@ -28,7 +28,7 @@ Bool is_modifier(KeySym key_sym);
 char*  get_wm_class_name(Window window);
 void   grab_button(int is_grab);
 void   grab_all_keys(Window window, int is_grab);
-unsigned char *get_win_prop(Window window, Atom atom, long *nitems, Atom *type, int *size);
+unsigned char *get_win_prop(Window window, Atom atom, unsigned long *nitems);
 void toggle_lock(int mask, int state);
 void click_key(KeySym keysym);
 

--- a/xneur/lib/main/window.c
+++ b/xneur/lib/main/window.c
@@ -67,7 +67,17 @@ static int is_has_net_supported(Display *display, Window window)
 	return result;
 }
 
-static int window_create(struct _window *p)
+static void window_uninit(struct _window *p)
+{
+	if (p->keymap != NULL)
+		p->keymap->uninit(p->keymap);
+
+	free(p);
+
+	log_message(DEBUG, _("Window is freed"));
+}
+
+struct _window* window_init(struct _xneur_handle *handle)
 {
 	XSetErrorHandler(error_handler);
 
@@ -75,7 +85,7 @@ static int window_create(struct _window *p)
 	if (!display)
 	{
 		log_message(ERROR, _("Can't connect to XServer"));
-		return FALSE;
+		return NULL;
 	}
 
 	Window root = DefaultRootWindow(display);
@@ -85,7 +95,7 @@ static int window_create(struct _window *p)
 	{
 		log_message(ERROR, _("Can't create program window"));
 		XCloseDisplay(display);
-		return FALSE;
+		return NULL;
 	}
 
 	// Create flag window
@@ -97,7 +107,7 @@ static int window_create(struct _window *p)
 	{
 		log_message(ERROR, _("Can't create flag window"));
 		XCloseDisplay(display);
-		return FALSE;
+		return NULL;
 	}
 
 	// Set no border mode to flag window
@@ -119,42 +129,27 @@ static int window_create(struct _window *p)
 
 	XChangeProperty(display, flag_window, win_prop, win_prop, 32, PropModeReplace, (unsigned char *) &mwmhints, sizeof (XWMHints) / 4);
 
-	p->display = display;
-	p->window  = window;
-	p->_NET_SUPPORTED = is_has_net_supported(display, root);
+	int _NET_SUPPORTED = is_has_net_supported(display, root);
 
 	log_message(LOG, _("Main window with id %d created"), window);
 
 	XSynchronize(display, TRUE);
 	XFlush(display);
 
-	return TRUE;
-}
+	struct _keymap* keymap = keymap_init(handle, display);
+	if (keymap == NULL) {
+		XCloseDisplay(display);
+		return NULL;
+	}
 
-static void window_uninit(struct _window *p)
-{
-	if (p->keymap != NULL)
-		p->keymap->uninit(p->keymap);
-
-	free(p);
-
-	log_message(DEBUG, _("Window is freed"));
-}
-
-struct _window* window_init(struct _xneur_handle *handle)
-{
 	struct _window *p = (struct _window *) malloc(sizeof(struct _window));
 	memset(p, 0, sizeof(struct _window));
 
-	if (!window_create(p)) {
-		free(p);
-		return NULL;
-	}
-	p->keymap = keymap_init(handle, p->display);
-	if (p->keymap == NULL) {
-		free(p);
-		return NULL;
-	}
+	p->keymap  = keymap;
+	p->display = display;
+	p->window  = window;
+	p->_NET_SUPPORTED = _NET_SUPPORTED;
+
 	// Function mapping
 	p->uninit = window_uninit;
 

--- a/xneur/lib/main/window.c
+++ b/xneur/lib/main/window.c
@@ -118,10 +118,8 @@ static int window_create(struct _window *p)
 
 	XChangeProperty(display, flag_window, win_prop, win_prop, 32, PropModeReplace, (unsigned char *) &mwmhints, sizeof (XWMHints) / 4);
 
-	p->display 	= display;
-	p->window  	= window;
-
-	p->internal_atom = XInternAtom(p->display, "XNEUR_INTERNAL_MSG", 0);
+	p->display = display;
+	p->window  = window;
 	p->_NET_SUPPORTED = is_has_net_supported(display, root);
 
 	log_message(LOG, _("Main window with id %d created"), window);

--- a/xneur/lib/main/window.c
+++ b/xneur/lib/main/window.c
@@ -103,23 +103,15 @@ static int window_create(struct _window *p)
 	p->internal_atom = XInternAtom(p->display, "XNEUR_INTERNAL_MSG", 0);
 
 	// Check "_NET_SUPPORTED" atom support
-	Atom type = 0;
-	long nitems = 0L;
-	int size = 0;
-	Atom *results = NULL;
-	long i = 0;
+	unsigned long nitems = 0L;
 
-	Window root;
-	Atom request;
-	Atom feature_atom;
-
-	request = XInternAtom(p->display, "_NET_SUPPORTED", False);
-	feature_atom = XInternAtom(p->display, "_NET_ACTIVE_WINDOW", False);
-	root = XDefaultRootWindow(p->display);
+	Atom request = XInternAtom(p->display, "_NET_SUPPORTED", False);
+	Atom feature_atom = XInternAtom(p->display, "_NET_ACTIVE_WINDOW", False);
+	Window root = XDefaultRootWindow(p->display);
 
 	p->_NET_SUPPORTED = FALSE;
-	results = (Atom *) get_win_prop(root, request, &nitems, &type, &size);
-	for (i = 0L; i < nitems; i++)
+	Atom *results = (Atom *) get_win_prop(root, request, &nitems);
+	for (unsigned long i = 0L; i < nitems; i++)
 	{
 		if (results[i] == feature_atom)
 			p->_NET_SUPPORTED = TRUE;

--- a/xneur/lib/main/window.c
+++ b/xneur/lib/main/window.c
@@ -105,12 +105,12 @@ static int window_create(struct _window *p)
 	// Check "_NET_SUPPORTED" atom support
 	unsigned long nitems = 0L;
 
-	Atom request = XInternAtom(p->display, "_NET_SUPPORTED", False);
-	Atom feature_atom = XInternAtom(p->display, "_NET_ACTIVE_WINDOW", False);
-	Window root = XDefaultRootWindow(p->display);
+	Atom request = XInternAtom(display, "_NET_SUPPORTED", False);
+	Atom feature_atom = XInternAtom(display, "_NET_ACTIVE_WINDOW", False);
+	Window root = XDefaultRootWindow(display);
 
 	p->_NET_SUPPORTED = FALSE;
-	Atom *results = (Atom *) get_win_prop(root, request, &nitems);
+	Atom *results = (Atom *) get_win_prop(display, root, request, &nitems);
 	for (unsigned long i = 0L; i < nitems; i++)
 	{
 		if (results[i] == feature_atom)

--- a/xneur/lib/main/window.h
+++ b/xneur/lib/main/window.h
@@ -26,8 +26,6 @@
 
 struct _window
 {
-	struct _xneur_handle *handle;
-
 	struct _keymap *keymap;
 
 	Display *display;
@@ -35,9 +33,6 @@ struct _window
 
 	int _NET_SUPPORTED;
 
-	int  (*create) (struct _window *p);
-	int  (*init_keymap) (struct _window *p);
-	void (*uninit_keymap) (struct _window *p);
 	void (*uninit) (struct _window *p);
 };
 

--- a/xneur/lib/main/window.h
+++ b/xneur/lib/main/window.h
@@ -33,8 +33,6 @@ struct _window
 	Display *display;
 	Window window;
 
-	Atom internal_atom;
-
 	int _NET_SUPPORTED;
 
 	int  (*create) (struct _window *p);

--- a/xneur/src/xneur.c
+++ b/xneur/src/xneur.c
@@ -53,6 +53,7 @@
 #include "popup.h"
 #include "notify.h"
 #include "plugin.h"
+#include "window.h"
 
 #include "newlang_creation.h"
 
@@ -326,6 +327,9 @@ static void xneur_reload(int status)
 
 	program->buffer->handle = xconfig->handle;
 	program->correction_buffer->handle = xconfig->handle;
+	if (main_window) {
+		main_window->keymap->handle = xconfig->handle;
+	}
 }
 
 static void xneur_usage(void)


### PR DESCRIPTION
В процессе избавления от глобальных переменных (их я в конце-концов засуну в структуру `_program`) я проводил рефакторинг и обнаружил некорректную работу с памятью.

В 7874203 исправлена деаллокация памяти, выделенной функциями X сервера. Она [должна](https://tronche.com/gui/x/xlib/window-information/XGetWindowProperty.html) освобождатьcя вызовом XFree, а в некоторых случаях для этого использовался вызов `free`. Исправлено копированием данных в память, которая может быть освобождена этим способом. Возможно из-за этого происходят некоторых краши, рапортованные пользователями.

Затем был рефакторинг получения свойств окон от X, в результате которой обнаружена и исправлена утечка памяти (dd92448).

В 8247887 я удалил код создания атома "XNEUR_INTERNAL_MSG". Я не понял, зачем он нужен, переменная, в которую он сохраняется, нигде не используется. Имя намекает, что эта штука не для использования другими клиентами X, поэтому я просто удалил его.

Затем пошел рефакторинг по упрощению создания окна (3 функции для этого явно перебор), в результате которой обнаружился еще один баг, из-за которого при перезагрузке xneur хендл обновлялся не во всех структурах, в которых он хранится (675f7c1).