### PR TITLE
Исправлены некоторые проблемы с памятью

### DIFF
--- a/gxneur/src/callbacks.c
+++ b/gxneur/src/callbacks.c
@@ -47,7 +47,8 @@ void new_rule_to_treeview(GtkButton *button, gpointer user_data)
 	printf("--->> '%s'\n", letters);
 	if (letters == NULL)
 	{
-		GtkWidget *window = GTK_WIDGET(gtk_builder_get_object (builder, "dialog1"));		gtk_widget_destroy(window);	
+		GtkWidget *window = GTK_WIDGET(gtk_builder_get_object (builder, "dialog1"));
+		gtk_widget_destroy(window);
 		printf("--->> 'DESTROY'\n");
 		return;
 	}
@@ -63,7 +64,7 @@ void new_rule_to_treeview(GtkButton *button, gpointer user_data)
 	{
 		gtk_list_store_set(GTK_LIST_STORE(store), &iter, 2, TRUE, -1);
 	}
-		
+
 	widgetPtrToBefound = GTK_WIDGET(gtk_builder_get_object (builder, "radiobutton1"));
 	if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON (widgetPtrToBefound)))
 	{
@@ -87,10 +88,10 @@ void new_rule_to_treeview(GtkButton *button, gpointer user_data)
 	{
 		gtk_list_store_set(GTK_LIST_STORE(store), &iter, 1, _(conditions_names1[3]), -1);
 	}
-		
+
 	GtkWidget *window = GTK_WIDGET(gtk_builder_get_object (builder, "dialog1"));
 	gtk_widget_destroy(window);
-}	
+}
 
 void on_addbutton_clicked(GtkButton *button, gpointer user_data)
 {
@@ -102,20 +103,20 @@ void on_addbutton_clicked(GtkButton *button, gpointer user_data)
 		g_warning ("Couldn't load builder file: %s", error->message);
 		g_error_free (error);
 	}
-	
+
 	GtkWidget *window = GTK_WIDGET(gtk_builder_get_object (builder, "dialog1"));
-	
+
 	gtk_widget_show(window);
 
 	xyz_t *ud = malloc(sizeof(xyz_t));
 	ud->x = builder;
 	ud->y = ((xyz_t *) user_data)->y;
-	
+
 	GtkWidget *widget= GTK_WIDGET(gtk_builder_get_object (builder, "button1"));
 	g_signal_connect ((gpointer) widget, "clicked", G_CALLBACK (new_rule_to_treeview), ud);
 	widget = GTK_WIDGET(gtk_builder_get_object (builder, "button2"));
 	g_signal_connect ((gpointer) widget, "clicked", G_CALLBACK (on_cancelbutton_clicked), ud);
-	
+
 }
 
 // Save new regexp rule
@@ -129,12 +130,13 @@ void edit_rule_to_treeview(GtkButton *button, gpointer user_data)
 	char *letters = strtok((char *) gtk_entry_get_text(GTK_ENTRY(widgetPtrToBefound)), " ");
 	if (letters == NULL)
 	{
-		GtkWidget *window = GTK_WIDGET(gtk_builder_get_object (builder, "dialog1"));		gtk_widget_destroy(window);	
+		GtkWidget *window = GTK_WIDGET(gtk_builder_get_object (builder, "dialog1"));
+		gtk_widget_destroy(window);
 		return;
 	}
 
 	GtkWidget *treeview = GTK_WIDGET(gtk_builder_get_object (((xyz_t *) user_data)->z, "treeview1"));
-	
+
 	GtkTreeSelection *select = gtk_tree_view_get_selection(GTK_TREE_VIEW(treeview));
 	gtk_tree_selection_set_mode(select, GTK_SELECTION_SINGLE);
 
@@ -147,7 +149,7 @@ void edit_rule_to_treeview(GtkButton *button, gpointer user_data)
 	widgetPtrToBefound = GTK_WIDGET(gtk_builder_get_object (builder, "checkbutton1"));
 	gboolean insensitive = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON (widgetPtrToBefound));
 	gtk_list_store_set(GTK_LIST_STORE(store), &iter, 2, insensitive, -1);
-		
+
 	widgetPtrToBefound = GTK_WIDGET(gtk_builder_get_object (builder, "radiobutton1"));
 	if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON (widgetPtrToBefound)))
 	{
@@ -171,17 +173,17 @@ void edit_rule_to_treeview(GtkButton *button, gpointer user_data)
 	{
 		gtk_list_store_set(GTK_LIST_STORE(store), &iter, 1, _(conditions_names1[3]), -1);
 	}
-		
+
 	GtkWidget *window = GTK_WIDGET(gtk_builder_get_object (builder, "dialog1"));
 	gtk_widget_destroy(window);
-}			
+}
 
 void on_editbutton_clicked(GtkButton *button, gpointer user_data)
 {
 	if (button){};
 
 	GtkWidget *treeview = GTK_WIDGET(gtk_builder_get_object (((xyz_t *) user_data)->x, "treeview1"));
-	
+
 	GtkTreeSelection *select = gtk_tree_view_get_selection(GTK_TREE_VIEW(treeview));
 	gtk_tree_selection_set_mode(select, GTK_SELECTION_SINGLE);
 
@@ -192,7 +194,7 @@ void on_editbutton_clicked(GtkButton *button, gpointer user_data)
 		gchar *letters;
 		gchar *condition;
 		gboolean insensitive;
-		gtk_tree_model_get(GTK_TREE_MODEL(model), &iter, 0, &letters, 
+		gtk_tree_model_get(GTK_TREE_MODEL(model), &iter, 0, &letters,
 	                                                     1, &condition,
 	                                                     2, &insensitive,
 	                                                     -1);
@@ -212,7 +214,7 @@ void on_editbutton_clicked(GtkButton *button, gpointer user_data)
 
 		GtkWidget *checkbutton = GTK_WIDGET(gtk_builder_get_object (builder, "checkbutton1"));
 		gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(checkbutton), insensitive);
-		
+
 		if (strcmp((const char*)condition, _(conditions_names1[0])) == 0)
 		{
 			GtkWidget *radiobutton = GTK_WIDGET(gtk_builder_get_object (builder, "radiobutton1"));
@@ -232,15 +234,15 @@ void on_editbutton_clicked(GtkButton *button, gpointer user_data)
 		{
 			GtkWidget *radiobutton = GTK_WIDGET(gtk_builder_get_object (builder, "radiobutton4"));
 			gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(radiobutton), TRUE);
-		}	
-		
+		}
+
 		gtk_widget_show(window);
 
 		xyz_t *ud = malloc(sizeof(xyz_t));
 		ud->x = builder;
 		ud->y = ((xyz_t *) user_data)->y;
 		ud->z = ((xyz_t *) user_data)->x;
-		
+
 		GtkWidget *widget= GTK_WIDGET(gtk_builder_get_object (builder, "button1"));
 		g_signal_connect ((gpointer) widget, "clicked", G_CALLBACK (edit_rule_to_treeview), ud);
 		widget = GTK_WIDGET(gtk_builder_get_object (builder, "button2"));
@@ -251,9 +253,9 @@ void on_editbutton_clicked(GtkButton *button, gpointer user_data)
 void on_deletebutton_clicked(GtkButton *button, gpointer user_data)
 {
 	if (button){};
-	
+
 	GtkWidget *treeview = GTK_WIDGET(gtk_builder_get_object (((xyz_t *) user_data)->x, "treeview1"));
-	
+
 	GtkTreeSelection *select = gtk_tree_view_get_selection(GTK_TREE_VIEW(treeview));
 	gtk_tree_selection_set_mode(select, GTK_SELECTION_SINGLE);
 
@@ -284,11 +286,11 @@ void on_extension_install_check(gpointer user_data)
 static gboolean save_regexp(GtkTreeModel *model, GtkTreePath *path, GtkTreeIter *iter, gpointer user_data)
 {
 	if (model || path || user_data){};
-	
+
 	gchar *letters;
 	gchar *condition;
 	gboolean insensitive;
-	gtk_tree_model_get(GTK_TREE_MODEL(model), iter, 0, &letters, 
+	gtk_tree_model_get(GTK_TREE_MODEL(model), iter, 0, &letters,
 	                                                1, &condition,
 	                                                2, &insensitive,
 	                                                -1);
@@ -297,7 +299,7 @@ static gboolean save_regexp(GtkTreeModel *model, GtkTreePath *path, GtkTreeIter 
 	{
 		fputs("(?i)", stream);
 	}
-		
+
 	if (strcmp((const char*)condition, _(conditions_names1[0])) == 0)
 	{
 		fputs(letters, stream);
@@ -321,10 +323,8 @@ static gboolean save_regexp(GtkTreeModel *model, GtkTreePath *path, GtkTreeIter 
 	fputs("\n", stream);
 
 	// end write
-	if (letters != NULL)
-		g_free(letters);
-	if (condition != NULL)
-		g_free(condition);
+	g_free(letters);
+	g_free(condition);
 
 	return FALSE;
 }
@@ -342,11 +342,10 @@ void on_okbutton_clicked(GtkButton *button, gpointer user_data)
 		gtk_tree_model_foreach(GTK_TREE_MODEL(((xyz_t *) user_data)->y), save_regexp, user_data);
 		fclose(stream);
 	}
-	
+
 	GtkWidget *window = GTK_WIDGET(gtk_builder_get_object (((xyz_t *) user_data)->x, "dialog1"));
 	gtk_widget_destroy(window);
-	if (user_data!= NULL)
-		g_free(user_data);
+	g_free(user_data);
 }
 
 void on_cancelbutton_clicked(GtkButton *button, gpointer user_data)
@@ -355,15 +354,14 @@ void on_cancelbutton_clicked(GtkButton *button, gpointer user_data)
 
 	GtkWidget *window = GTK_WIDGET(gtk_builder_get_object (((xyz_t *) user_data)->x, "dialog1"));
 	gtk_widget_destroy(window);
-	if (user_data != NULL)
-		g_free(user_data);
+	g_free(user_data);
 }
 
 // Parse keyboard binds
 gboolean on_key_press_event(GtkWidget *widget, GdkEventKey *event, gpointer user_data)
 {
 	if (user_data){};
-		
+
 	char *string		= XKeysymToString(XkbKeycodeToKeysym(gdk_x11_get_default_xdisplay(), event->hardware_keycode, 0, 0));
 	gchar *modifiers	= modifiers_to_string(event->state);
 	gchar *keycode		= g_strdup_printf("%d", event->hardware_keycode);
@@ -371,13 +369,10 @@ gboolean on_key_press_event(GtkWidget *widget, GdkEventKey *event, gpointer user
 
 	gtk_entry_set_text(GTK_ENTRY(widget), mkey);
 
-	if (mkey != NULL)
-		g_free(mkey);
-	if (keycode != NULL)
-		g_free(keycode);
-	if (modifiers != NULL)
-		g_free(modifiers);
-		
+	g_free(mkey);
+	g_free(keycode);
+	g_free(modifiers);
+
 	return FALSE;
 }
 

--- a/gxneur/src/configuration.c
+++ b/gxneur/src/configuration.c
@@ -68,7 +68,7 @@ int gxneur_config_read_str(const char* key, gchar** value)
 		return -2;
 
 	*value = g_settings_get_string(gsettingsSet(), key);
-	return 0;	
+	return 0;
 }
 
 int gxneur_config_write_int(const char* key, int value)
@@ -79,8 +79,8 @@ int gxneur_config_write_int(const char* key, int value)
 	if (!key)
 		return -2;
 
-	
-	if(!g_settings_set_int(gsettingsSet(), key, value)) 
+
+	if(!g_settings_set_int(gsettingsSet(), key, value))
 	{
 		    g_warning("Failed to set %s (%d)\n", key, value);
 		    return -1;
@@ -98,7 +98,7 @@ int gxneur_config_write_str(const char* key, const char* value)
 
 	int result = 0;
 
-	if(!g_settings_set_string(gsettingsSet(), key, value)) 
+	if(!g_settings_set_string(gsettingsSet(), key, value))
 		    g_warning("Failed to set %s (%s)\n", key, value),
 		    result = -1;
 
@@ -112,16 +112,15 @@ int gxneur_config_add_notify(const char* key, void* callback)
 
 	gchar* k = g_strdup_printf("changed::%s", key);
 	g_assert(k != NULL);
-	
+
 	g_signal_connect (
 				gsettingsSet(),
 				k,
 				G_CALLBACK (callback),
 				NULL);
-	
-	if (k != NULL)
-		g_free(k);
-	
+
+	g_free(k);
+
 	return 0;
 }
 

--- a/gxneur/src/misc.c
+++ b/gxneur/src/misc.c
@@ -218,10 +218,8 @@ void xneur_get_logfile()
 	strncat(command, TO_STDOUT, sizeof(TO_STDOUT)-1);
 
 	FILE *fp = popen(command, "r");
-	if (log_home_path != NULL)
-		g_free(log_home_path);
-	if (command != NULL)
-		g_free(command);
+	g_free(log_home_path);
+	g_free(command);
 	if (fp == NULL)
 		return;
 
@@ -297,8 +295,7 @@ static void save_list(GtkListStore *store, struct _list_char *list, GtkTreeIter 
 
 	list->add(list, ptr);
 
-	if (ptr != NULL)
-		g_free(ptr);
+	g_free(ptr);
 }
 
 static void init_libxnconfig(void)
@@ -453,15 +450,14 @@ static void xneur_edit_icons_directory(GtkBuilder* parent_builder)
 
 	res = gtk_dialog_run (GTK_DIALOG (dialog));
 	if (res == GTK_RESPONSE_ACCEPT)
-	  {
+	{
 		char *dirname;
 		GtkFileChooser *chooser = GTK_FILE_CHOOSER (dialog);
 		dirname = gtk_file_chooser_get_filename (chooser);
 		tmp_widget = GTK_WIDGET(gtk_builder_get_object (parent_builder, "entry1"));
 		gtk_entry_set_text(GTK_ENTRY(tmp_widget), dirname);
-		if (dirname != NULL)
-			g_free (dirname);
-	  }
+		g_free(dirname);
+	}
 
 	gtk_widget_destroy (dialog);
 }
@@ -494,8 +490,7 @@ void xneur_kb_preference(void)
 	gchar *string_value = NULL;
 	gxneur_config_read_str("keyboard-properties", &string_value);
 	if (arg_keyboard_properties) {
-		if (string_value != NULL)
-			g_free(string_value);
+		g_free(string_value);
 		string_value = g_strdup(arg_keyboard_properties);
 	}
 
@@ -507,8 +502,7 @@ void xneur_kb_preference(void)
 		fprintf(stderr, _("Couldn't start %s\nVerify that it installed\n"), cmd);
 	}
 
-	if (string_value != NULL)
-		g_free(string_value);
+	g_free(string_value);
 }
 
 void xneur_preference(void)
@@ -909,8 +903,7 @@ void xneur_preference(void)
 												0, replacement,
 												1, string,
 												-1);
-		if (replacement != NULL)
-			g_free(replacement);
+		g_free(replacement);
 	}
 
 	cell = gtk_cell_renderer_text_new();
@@ -1075,8 +1068,7 @@ void xneur_preference(void)
 												1, text,
 												2, xconfig->user_actions[action].command,
 												-1);
-		if (text != NULL)
-			g_free(text);
+		g_free(text);
 	}
 
 	cell = gtk_cell_renderer_text_new();
@@ -1295,8 +1287,7 @@ void xneur_preference(void)
 			char * plugin_file = malloc(sizeof(char)*len);
 			snprintf(plugin_file, len, "%s/%s", XNEUR_PLUGIN_DIR, ep->d_name);
 			void *module = dlopen(plugin_file, RTLD_NOW);
-			if (plugin_file != NULL)
-				g_free(plugin_file);
+			g_free(plugin_file);
 			if(!module)
 			{
 				ep = readdir (dp);
@@ -1340,8 +1331,7 @@ void xneur_preference(void)
 	// Autostart
 	gchar *path_file = g_build_filename(getenv("HOME"), AUTOSTART_PATH, AUTOSTART_FILE, NULL);
 	FILE *stream = fopen(path_file, "r");
-	if (path_file != NULL)
-		g_free(path_file);
+	g_free(path_file);
 	if (stream != NULL)
 	{
 		fclose(stream);
@@ -1356,8 +1346,7 @@ void xneur_preference(void)
 	{
 	    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), TRUE);
 	}
-	if (path_file != NULL)
-		g_free(path_file);
+	g_free(path_file);
 	g_signal_connect_swapped(G_OBJECT(widget), "clicked", G_CALLBACK(on_extension_install_check), G_OBJECT(widget));
 
 	// Delay before start
@@ -1376,8 +1365,7 @@ void xneur_preference(void)
 	if (gxneur_config_read_str("show-in-the-tray", &string_value) == CONFIG_NOT_SUPPORTED)
 		gtk_widget_set_sensitive(GTK_WIDGET(widget), FALSE);
 	if (arg_show_in_the_tray) {
-		if (string_value != NULL)
-			g_free(string_value);
+		g_free(string_value);
 		string_value = g_strdup(arg_show_in_the_tray);
 	}
 	if (!string_value)
@@ -1391,8 +1379,7 @@ void xneur_preference(void)
 	else
 		show_in_the_tray = 3;
 	gtk_combo_box_set_active(GTK_COMBO_BOX(widget), show_in_the_tray);
-	if (string_value != NULL)
-		g_free(string_value);
+	g_free(string_value);
 
 	// Define icons directory
 	widget = GTK_WIDGET(gtk_builder_get_object (builder, "entry1"));
@@ -1401,8 +1388,7 @@ void xneur_preference(void)
 	if (gxneur_config_read_str("icons-directory", &string_value) == CONFIG_NOT_SUPPORTED)
 		gtk_widget_set_sensitive(GTK_WIDGET(widget), FALSE), icons_directory_config_not_supported = 1;
 	gtk_entry_set_text(GTK_ENTRY(widget), string_value ? string_value : "");
-	if (string_value != NULL)
-		g_free(string_value);
+	g_free(string_value);
 
 	// Button Icons Directory Edit
 	widget = GTK_WIDGET(gtk_builder_get_object (builder, "button18"));
@@ -1419,8 +1405,7 @@ void xneur_preference(void)
 		gtk_widget_set_sensitive(GTK_WIDGET(widget), FALSE);
 
 	if (arg_rendering_engine) {
-		if (string_value != NULL)
-			g_free(string_value);
+		g_free(string_value);
 		string_value = g_strdup(arg_rendering_engine);
 	}
 	if (!string_value)
@@ -1441,13 +1426,11 @@ void xneur_preference(void)
 		gtk_widget_set_sensitive(GTK_WIDGET(widget), FALSE),
 		keyboard_properties_config_not_supported = 1;
 	if (arg_keyboard_properties) {
-		if (string_value != NULL)
-			g_free(string_value);
+		g_free(string_value);
 		string_value = g_strdup(arg_keyboard_properties);
 	}
 	gtk_entry_set_text(GTK_ENTRY(widget), string_value ? string_value : DEFAULT_KEYBOARD_PROPERTIES);
-	if (string_value != NULL)
-		g_free(string_value);
+	g_free(string_value);
 
 	// Button Keyboard properties Edit
 	widget = GTK_WIDGET(gtk_builder_get_object (builder, "button15"));
@@ -1930,10 +1913,8 @@ void xneur_edit_dictionary(GtkWidget *treeview)
 
 		if (text == NULL)
 		{
-			if (text_home_path != NULL)
-				g_free(text_home_path);
-			if (text_path != NULL)
-				g_free(text_path);
+			g_free(text_home_path);
+			g_free(text_path);
 			return;
 		}
 
@@ -2025,12 +2006,9 @@ void xneur_edit_dictionary(GtkWidget *treeview)
 		widget = GTK_WIDGET(gtk_builder_get_object (builder, "cancelbutton"));
 		g_signal_connect ((gpointer) widget, "clicked", G_CALLBACK (on_cancelbutton_clicked), ud);
 
-		if (text != NULL)
-			g_free(text);
-		if (text_home_path != NULL)
-			g_free(text_home_path);
-		if (text_path != NULL)
-			g_free(text_path);
+		g_free(text);
+		g_free(text_home_path);
+		g_free(text_path);
 	}
 }
 
@@ -2165,12 +2143,9 @@ gboolean save_abbreviation(GtkTreeModel *model, GtkTreePath *path, GtkTreeIter *
 		xconfig->abbreviations->add(xconfig->abbreviations, ptr);
 	}
 
-	if (abbreviation != NULL)
-		g_free(abbreviation);
-	if (full_text != NULL)
-		g_free(full_text);
-	if (ptr != NULL)
-		g_free(ptr);
+	g_free(abbreviation);
+	g_free(full_text);
+	g_free(ptr);
 
 	return FALSE;
 }
@@ -2227,12 +2202,9 @@ gboolean save_user_action(GtkTreeModel *model, GtkTreePath *path, GtkTreeIter *i
 
 	g_strfreev(key_stat);
 
-	if (key_bind != NULL)
-		g_free(key_bind);
-	if (action_text != NULL)
-		g_free(action_text);
-	if (action_name != NULL)
-		g_free(action_name);
+	g_free(key_bind);
+	g_free(action_text);
+	g_free(action_name);
 
 	return FALSE;
 }
@@ -2284,10 +2256,8 @@ gboolean save_action(GtkTreeModel *model, GtkTreePath *path, GtkTreeIter *iter, 
 
 	g_strfreev(key_stat);
 
-	if (key_bind != NULL)
-		g_free(key_bind);
-	if (action_text != NULL)
-		g_free(action_text);
+	g_free(key_bind);
+	g_free(action_text);
 
 	return FALSE;
 }
@@ -2301,8 +2271,8 @@ gboolean save_sound(GtkTreeModel *model, GtkTreePath *path, GtkTreeIter *iter, g
 	gtk_tree_model_get(GTK_TREE_MODEL(store_sound), iter, 1, &file_path, 2, &enabled, -1);
 
 	int i = atoi(gtk_tree_path_to_string(path));
-	if (xconfig->sounds[i].file != NULL)
-		g_free(xconfig->sounds[i].file);
+	g_free(xconfig->sounds[i].file);
+	xconfig->sounds[i].file = NULL;
 
 	if (file_path != NULL)
 	{
@@ -2324,8 +2294,8 @@ gboolean save_osd(GtkTreeModel *model, GtkTreePath *path, GtkTreeIter *iter, gpo
 	gtk_tree_model_get(GTK_TREE_MODEL(store_osd), iter, 1, &string, 2, &enabled, -1);
 
 	int i = atoi(gtk_tree_path_to_string(path));
-	if (xconfig->osds[i].file != NULL)
-		g_free(xconfig->osds[i].file);
+	g_free(xconfig->osds[i].file);
+	xconfig->osds[i].file = NULL;
 
 	if (string != NULL)
 	{
@@ -2347,8 +2317,8 @@ gboolean save_popup(GtkTreeModel *model, GtkTreePath *path, GtkTreeIter *iter, g
 	gtk_tree_model_get(GTK_TREE_MODEL(store_popup), iter, 1, &string, 2, &enabled, -1);
 
 	int i = atoi(gtk_tree_path_to_string(path));
-	if (xconfig->popups[i].file != NULL)
-		g_free(xconfig->popups[i].file);
+	g_free(xconfig->popups[i].file);
+	xconfig->popups[i].file = NULL;
 
 	if (string != NULL)
 	{
@@ -2451,14 +2421,12 @@ void xneur_save_preference(GtkBuilder* builder)
 
 	// Log send to e-mail
 	widgetPtrToBefound = GTK_WIDGET(gtk_builder_get_object (builder, "entry3"));
-	if (xconfig->mail_keyboard_log != NULL)
-		g_free(xconfig->mail_keyboard_log);
+	g_free(xconfig->mail_keyboard_log);
 	xconfig->mail_keyboard_log = strdup((char *) gtk_entry_get_text(GTK_ENTRY(widgetPtrToBefound)));
 
 	// Log send via host
 	widgetPtrToBefound = GTK_WIDGET(gtk_builder_get_object (builder, "entry4"));
-	if (xconfig->host_keyboard_log != NULL)
-		g_free(xconfig->host_keyboard_log);
+	g_free(xconfig->host_keyboard_log);
 	xconfig->host_keyboard_log = strdup((char *) gtk_entry_get_text(GTK_ENTRY(widgetPtrToBefound)));
 
 	// Log port
@@ -2544,8 +2512,7 @@ void xneur_save_preference(GtkBuilder* builder)
 	xconfig->popup_expire_timeout = gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(widgetPtrToBefound));
 
 	widgetPtrToBefound = GTK_WIDGET(gtk_builder_get_object (builder, "entry2"));
-	if (xconfig->osd_font != NULL)
-		g_free(xconfig->osd_font);
+	g_free(xconfig->osd_font);
 	xconfig->osd_font = strdup((char *) gtk_entry_get_text(GTK_ENTRY(widgetPtrToBefound)));
 
 	// Troubleshooting
@@ -2590,8 +2557,7 @@ void xneur_save_preference(GtkBuilder* builder)
 	gchar *path_file = g_build_filename(getenv("HOME"), AUTOSTART_PATH, NULL);
 	if (!g_file_test(path_file, G_FILE_TEST_IS_DIR))
 		g_mkdir_with_parents(path_file, S_IRUSR | S_IWUSR | S_IXUSR | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH);
-	if (path_file != NULL)
-		g_free(path_file);
+	g_free(path_file);
 
 	path_file = g_build_filename(getenv("HOME"), AUTOSTART_PATH, AUTOSTART_FILE, NULL);
 	FILE *stream = fopen(path_file, "r");
@@ -2619,8 +2585,7 @@ void xneur_save_preference(GtkBuilder* builder)
 			remove(path_file);
 		}
 	}
-	if (path_file != NULL)
-		g_free(path_file);
+	g_free(path_file);
 
 	// Gnome 3 Shell Area
 	widgetPtrToBefound = GTK_WIDGET(gtk_builder_get_object (builder, "checkbutton36"));
@@ -2628,8 +2593,7 @@ void xneur_save_preference(GtkBuilder* builder)
 	path_file = g_build_filename(getenv("HOME"), GNOME3_EXT_PATH, NULL);
 	if (!g_file_test(path_file, G_FILE_TEST_IS_DIR))
 		g_mkdir_with_parents(path_file, S_IRUSR | S_IWUSR | S_IXUSR | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH);
-	if (path_file != NULL)
-		g_free(path_file);
+	g_free(path_file);
 
 	path_file = g_build_filename(getenv("HOME"), GNOME3_EXT_PATH, GNOME3_EXT_JS_FILE, NULL);
 	stream = fopen(path_file, "r");
@@ -2668,8 +2632,7 @@ void xneur_save_preference(GtkBuilder* builder)
 			remove(path_file);
 		}
 	}
-	if (path_file != NULL)
-		g_free(path_file);
+	g_free(path_file);
 
 	path_file = g_build_filename(getenv("HOME"), GNOME3_EXT_PATH, GNOME3_EXT_JSON_FILE, NULL);
 	stream = fopen(path_file, "r");
@@ -2701,16 +2664,14 @@ void xneur_save_preference(GtkBuilder* builder)
 			remove(path_file);
 		}
 	}
-	if (path_file != NULL)
-		g_free(path_file);
+	g_free(path_file);
 
 	path_file = g_build_filename(getenv("HOME"), GNOME3_EXT_PATH, NULL);
 	if (!gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON (widgetPtrToBefound)))
 	{
 		g_rmdir(path_file);
 	}
-	if (path_file != NULL)
-		g_free(path_file);
+	g_free(path_file);
 
 	// Delay
 	widgetPtrToBefound = GTK_WIDGET(gtk_builder_get_object (builder, "spinbutton5"));
@@ -2782,8 +2743,7 @@ char* xneur_get_file_content(const char *path)
 	char *content = (char *) malloc((file_len + 2) * sizeof(char)); // + '\n' + '\0'
 	if (fread(content, 1, file_len, stream) != file_len)
 	{
-		if (content != NULL)
-			g_free(content);
+		g_free(content);
 		fclose(stream);
 		return NULL;
 	}

--- a/gxneur/src/misc.c
+++ b/gxneur/src/misc.c
@@ -136,8 +136,7 @@ void error_msg(const char *msg, ...)
 	va_list ap;
 	va_start(ap, msg);
 
-	char *buffer = (char *) malloc(sizeof(char)*1024*10);
-	memset(buffer, 0, sizeof(char)*1024*10);
+	char buffer[1024*10] = {0};
 	vsprintf(buffer, msg, ap);
 
 	GtkWidget *dialog = gtk_message_dialog_new (NULL,
@@ -148,8 +147,6 @@ void error_msg(const char *msg, ...)
 	gtk_dialog_run (GTK_DIALOG (dialog));
 	gtk_widget_destroy (dialog);
 
-	if (buffer != NULL)
-		g_free(buffer);
 	va_end(ap);
 }
 

--- a/gxneur/src/misc.c
+++ b/gxneur/src/misc.c
@@ -218,8 +218,8 @@ void xneur_get_logfile()
 	strncat(command, TO_STDOUT, sizeof(TO_STDOUT)-1);
 
 	FILE *fp = popen(command, "r");
-	g_free(log_home_path);
-	g_free(command);
+	free(log_home_path);
+	free(command);
 	if (fp == NULL)
 		return;
 
@@ -2743,7 +2743,7 @@ char* xneur_get_file_content(const char *path)
 	char *content = (char *) malloc((file_len + 2) * sizeof(char)); // + '\n' + '\0'
 	if (fread(content, 1, file_len, stream) != file_len)
 	{
-		g_free(content);
+		free(content);
 		fclose(stream);
 		return NULL;
 	}

--- a/gxneur/src/trayicon.c
+++ b/gxneur/src/trayicon.c
@@ -336,13 +336,11 @@ gboolean clock_check(gpointer dummy)
 	if (dummy) {};
 
 	int xneur_pid = -1;
-	char *ps_command = (char *) malloc(1024 * sizeof(char));
 	if (xneur_old_pid == -1)
 		xneur_old_pid = 1;
-	snprintf(ps_command, 1024, "ps -p %d | grep xneur", xneur_old_pid);
+	char ps_command[20 + 30];// 20 - length of format string, 30 - more, than maximum length of int in decimal format
+	snprintf(ps_command, sizeof(ps_command)/sizeof(ps_command[0]), "ps -p %d | grep xneur", xneur_old_pid);
 	FILE *fp = popen(ps_command, "r");
-	if (ps_command != NULL)
-		g_free (ps_command);
 	if (fp != NULL)
 	{
 		char buffer[NAME_MAX];

--- a/gxneur/src/trayicon.c
+++ b/gxneur/src/trayicon.c
@@ -72,7 +72,7 @@ static void exec_user_action(char *cmd)
 	strncat(command, TO_STDOUT, sizeof(TO_STDOUT)-1);
 
 	FILE *fp = popen(command, "r");
-	g_free(command);
+	free(command);
 	if (fp == NULL)
 		return;
 
@@ -369,7 +369,7 @@ gboolean clock_check(gpointer dummy)
 	    strcmp(xneur_old_symbol, xneur_symbol) == 0 &&
 		force_update == FALSE)
 	{
-		g_free(xneur_symbol);
+		free(xneur_symbol);
 		return TRUE;
 	}
 	force_update = FALSE;
@@ -379,7 +379,7 @@ gboolean clock_check(gpointer dummy)
 	xneur_old_group = xneur_group;
 	if (xneur_old_symbol != NULL)
 	{
-		g_free(xneur_old_symbol);
+		free(xneur_old_symbol);
 	}
 	xneur_old_symbol = xneur_symbol;
 
@@ -413,7 +413,7 @@ gboolean clock_check(gpointer dummy)
 				layout_name[i] = toupper(layout_name[i]);
 			tray->image = gtk_label_new ((const gchar *)layout_name);
 			gtk_label_set_justify (GTK_LABEL(tray->image), GTK_JUSTIFY_CENTER);
-			g_free(layout_name);
+			free(layout_name);
 		}
 		else
 		{
@@ -435,7 +435,7 @@ gboolean clock_check(gpointer dummy)
 				for (unsigned int i=0; i < strlen(layout_name); i++)
 					layout_name[i] = toupper(layout_name[i]);
 				GdkPixbuf *pb = text_to_gtk_pixbuf (layout_name);
-				g_free(layout_name);
+				free(layout_name);
 				pb = gdk_pixbuf_add_alpha(pb, TRUE, 255, 255, 255);
 				gtk_status_icon_set_from_pixbuf(tray->status_icon, pb);
 				g_object_unref(pb);
@@ -463,7 +463,7 @@ gboolean clock_check(gpointer dummy)
 			for (unsigned int i=0; i < strlen(layout_name); i++)
 				layout_name[i] = toupper(layout_name[i]);
 			app_indicator_set_label (tray->app_indicator, layout_name, layout_name);
-			g_free(layout_name);
+			free(layout_name);
 			app_indicator_set_icon_full (tray->app_indicator, "", "");
 #endif
 		}
@@ -650,14 +650,14 @@ void create_tray_icon (void)
 					layout_name[i] = toupper(layout_name[i]);
 				tray->image = gtk_label_new ((const gchar *)layout_name);
 				gtk_label_set_justify (GTK_LABEL(tray->image), GTK_JUSTIFY_CENTER);
-				g_free(layout_name);
+				free(layout_name);
 			}
 			else
 			{
 				char *layout_name = get_active_kbd_symbol (dpy);
 				tray->image = gtk_image_new_from_icon_name(layout_name, GTK_ICON_SIZE_LARGE_TOOLBAR);
 				//tray->image = gtk_image_new_from_icon_name(tray->images[kbd_gr], GTK_ICON_SIZE_LARGE_TOOLBAR);
-				g_free(layout_name);
+				free(layout_name);
 			}
 			gtk_container_add(GTK_CONTAINER(tray->evbox), tray->image);
 			gtk_container_add(GTK_CONTAINER(tray->tray_icon), tray->evbox);
@@ -692,7 +692,7 @@ void create_tray_icon (void)
 				layout_name[i] = toupper(layout_name[i]);
 
 			GdkPixbuf *pb = text_to_gtk_pixbuf (layout_name);
-			g_free(layout_name);
+			free(layout_name);
 			pb = gdk_pixbuf_add_alpha(pb, TRUE, 255, 255, 255);
 			gtk_status_icon_set_from_pixbuf(tray->status_icon, pb);
 			g_object_unref(pb);
@@ -702,7 +702,7 @@ void create_tray_icon (void)
 			char *layout_name = get_active_kbd_symbol (dpy);
 			//gtk_status_icon_set_from_icon_name(tray->status_icon, tray->images[kbd_gr]);
 			gtk_status_icon_set_from_icon_name(tray->status_icon, layout_name);
-			g_free(layout_name);
+			free(layout_name);
 		}
 	}
 

--- a/gxneur/src/trayicon.c
+++ b/gxneur/src/trayicon.c
@@ -72,8 +72,7 @@ static void exec_user_action(char *cmd)
 	strncat(command, TO_STDOUT, sizeof(TO_STDOUT)-1);
 
 	FILE *fp = popen(command, "r");
-	if (command != NULL)
-		g_free(command);
+	g_free(command);
 	if (fp == NULL)
 		return;
 
@@ -121,8 +120,7 @@ GtkMenu* create_menu(struct _tray_icon *tray, int state)
 		gtk_menu_item_set_label(GTK_MENU_ITEM(tray->status), status_text);
 	}
 
-	if (status_text != NULL)
-		g_free(status_text);
+	g_free(status_text);
 
 	// Separator
 	menuitem = gtk_separator_menu_item_new();
@@ -244,8 +242,7 @@ GdkPixbuf *text_to_gtk_pixbuf (gchar *text)
 	//gchar *markup = g_strdup_printf ("<span color='%s'>%s</span>", textcolor, text);
 	gchar *markup = g_strdup_printf ("%s", text);
 	pango_layout_set_markup (layout, markup, -1);
-	if (markup != NULL)
-		g_free (markup);
+	g_free(markup);
 	//g_free (bgcolor);
 	//g_free (textcolor);
 
@@ -304,8 +301,7 @@ static const char *get_tray_icon_name (char *name)
 			if (g_file_test (icon_name, G_FILE_TEST_EXISTS))
 				return icon_name;
 		}
-		if (string_value != NULL)
- 			g_free (string_value);
+		g_free(string_value);
 		icon_name = PACKAGE;
 		return icon_name;
 	}
@@ -373,8 +369,7 @@ gboolean clock_check(gpointer dummy)
 	    strcmp(xneur_old_symbol, xneur_symbol) == 0 &&
 		force_update == FALSE)
 	{
-		if (xneur_symbol != NULL)
-			g_free(xneur_symbol);
+		g_free(xneur_symbol);
 		return TRUE;
 	}
 	force_update = FALSE;
@@ -418,8 +413,7 @@ gboolean clock_check(gpointer dummy)
 				layout_name[i] = toupper(layout_name[i]);
 			tray->image = gtk_label_new ((const gchar *)layout_name);
 			gtk_label_set_justify (GTK_LABEL(tray->image), GTK_JUSTIFY_CENTER);
-			if (layout_name != NULL)
-				g_free(layout_name);
+			g_free(layout_name);
 		}
 		else
 		{
@@ -441,8 +435,7 @@ gboolean clock_check(gpointer dummy)
 				for (unsigned int i=0; i < strlen(layout_name); i++)
 					layout_name[i] = toupper(layout_name[i]);
 				GdkPixbuf *pb = text_to_gtk_pixbuf (layout_name);
-				if (layout_name != NULL)
-					g_free(layout_name);
+				g_free(layout_name);
 				pb = gdk_pixbuf_add_alpha(pb, TRUE, 255, 255, 255);
 				gtk_status_icon_set_from_pixbuf(tray->status_icon, pb);
 				g_object_unref(pb);
@@ -470,8 +463,7 @@ gboolean clock_check(gpointer dummy)
 			for (unsigned int i=0; i < strlen(layout_name); i++)
 				layout_name[i] = toupper(layout_name[i]);
 			app_indicator_set_label (tray->app_indicator, layout_name, layout_name);
-			if (layout_name != NULL)
-				g_free(layout_name);
+			g_free(layout_name);
 			app_indicator_set_icon_full (tray->app_indicator, "", "");
 #endif
 		}
@@ -487,10 +479,8 @@ gboolean clock_check(gpointer dummy)
 	}
 #endif
 
-	if (hint != NULL)
-		g_free (hint);
-	if (status_text != NULL)
-		g_free (status_text);
+	g_free(hint);
+	g_free(status_text);
 
 	return TRUE;
 }
@@ -511,8 +501,7 @@ void xneur_exit(void)
 {
 	/*for (int i = 0; i < MAX_LAYOUTS; i++)
 	{
-		if (tray->images[i] != NULL)
-			g_free(tray->images[i]);
+		g_free(tray->images[i]);
 	}*/
 
 	gtk_widget_destroy(GTK_WIDGET(tray->menu));
@@ -552,8 +541,7 @@ void rendering_engine_callback(gpointer user_data)
 
 	/*for (int i = 0; i < MAX_LAYOUTS; i++)
 	{
-		if (tray->images[i] != NULL)
-			g_free(tray->images[i]);
+		g_free(tray->images[i]);
 	}*/
 
 	gtk_widget_destroy(GTK_WIDGET(tray->menu));
@@ -576,14 +564,12 @@ void create_tray_icon (void)
 
 	if (arg_show_in_the_tray)
 	{
-		if (show_in_the_tray != NULL)
-			g_free(show_in_the_tray);
+		g_free(show_in_the_tray);
 		show_in_the_tray = g_strdup(arg_show_in_the_tray);
 	}
 	if (arg_rendering_engine)
 	{
-		if (rendering_engine != NULL)
-			g_free(rendering_engine);
+		g_free(rendering_engine);
 		rendering_engine = g_strdup(arg_rendering_engine);
 	}
 
@@ -664,16 +650,14 @@ void create_tray_icon (void)
 					layout_name[i] = toupper(layout_name[i]);
 				tray->image = gtk_label_new ((const gchar *)layout_name);
 				gtk_label_set_justify (GTK_LABEL(tray->image), GTK_JUSTIFY_CENTER);
-				if (layout_name != NULL)
-					g_free(layout_name);
+				g_free(layout_name);
 			}
 			else
 			{
 				char *layout_name = get_active_kbd_symbol (dpy);
 				tray->image = gtk_image_new_from_icon_name(layout_name, GTK_ICON_SIZE_LARGE_TOOLBAR);
 				//tray->image = gtk_image_new_from_icon_name(tray->images[kbd_gr], GTK_ICON_SIZE_LARGE_TOOLBAR);
-				if (layout_name != NULL)
-					g_free(layout_name);
+				g_free(layout_name);
 			}
 			gtk_container_add(GTK_CONTAINER(tray->evbox), tray->image);
 			gtk_container_add(GTK_CONTAINER(tray->tray_icon), tray->evbox);
@@ -708,8 +692,7 @@ void create_tray_icon (void)
 				layout_name[i] = toupper(layout_name[i]);
 
 			GdkPixbuf *pb = text_to_gtk_pixbuf (layout_name);
-			if (layout_name != NULL)
-				g_free(layout_name);
+			g_free(layout_name);
 			pb = gdk_pixbuf_add_alpha(pb, TRUE, 255, 255, 255);
 			gtk_status_icon_set_from_pixbuf(tray->status_icon, pb);
 			g_object_unref(pb);
@@ -719,8 +702,7 @@ void create_tray_icon (void)
 			char *layout_name = get_active_kbd_symbol (dpy);
 			//gtk_status_icon_set_from_icon_name(tray->status_icon, tray->images[kbd_gr]);
 			gtk_status_icon_set_from_icon_name(tray->status_icon, layout_name);
-			if (layout_name != NULL)
-				g_free(layout_name);
+			g_free(layout_name);
 		}
 	}
 

--- a/gxneur/src/xkb.c
+++ b/gxneur/src/xkb.c
@@ -16,7 +16,7 @@
  *  Copyright (C) 2006-2010 XNeur Team
  *
  */
- 
+
 
 #include <string.h>
 #include <stdio.h>
@@ -27,7 +27,7 @@
 
 int isXkbLayoutSymbol(char *symbol)
 {
-	if ((strcmp(symbol, "group") == 0) || 
+	if ((strcmp(symbol, "group") == 0) ||
 	    (strcmp(symbol, "inet") == 0) ||
 	    (strcmp(symbol, "pc") == 0))
 	{
@@ -38,46 +38,44 @@ int isXkbLayoutSymbol(char *symbol)
 void XkbSymbolParse(const char *symbols, struct _xkb_name *symbolList)
 {
 	int inSymbol = 0;
-	
+
 	char *curSymbol = (char *) malloc (sizeof(char));
 	char *curVariant = (char *) malloc (sizeof(char));
 	curSymbol[0] = '\0';
 	curVariant[0] = '\0';
-	
+
 	int curLayout = 0;
-	
+
 	//printf("%s", symbols);
 	// A sample line:
 	// pc+fi(dvorak)+fi:2+ru:3+inet(evdev)+group(menu_toggle)
-    
-	for (size_t i = 0; i < strlen(symbols); i++) 
+
+	for (size_t i = 0; i < strlen(symbols); i++)
 	{
 		char ch = symbols[i];
-		if (ch == '+' || ch == '_') 
+		if (ch == '+' || ch == '_')
 		{
-			if (inSymbol) 
+			if (inSymbol)
 			{
-				if (isXkbLayoutSymbol(curSymbol)) 
+				if (isXkbLayoutSymbol(curSymbol))
 				{
 					symbolList[curLayout].symbol = (char *)strdup(curSymbol);
 					symbolList[curLayout].variant = (char *)strdup(curVariant);
 					curLayout++;
 				}
-				if (curSymbol != NULL)
-					free(curSymbol);
+				free(curSymbol);
 				curSymbol = (char *) malloc (sizeof(char));
-				if (curVariant != NULL)
-					free(curVariant);
+				free(curVariant);
 				curVariant = (char *) malloc (sizeof(char));
 				curSymbol[0] = '\0';
 				curVariant[0] = '\0';
-			} 
-			else 
+			}
+			else
 			{
 				inSymbol = 1;
 			}
-		} 
-		else if (inSymbol && (isalpha(ch) || ch == '_')) 
+		}
+		else if (inSymbol && (isalpha(ch) || ch == '_'))
 		{
 			int len = strlen(curSymbol);
 			char *tmpSymbol = (char *) realloc (curSymbol, sizeof(char)*(len+2));
@@ -87,10 +85,10 @@ void XkbSymbolParse(const char *symbols, struct _xkb_name *symbolList)
 				curSymbol[len] = ch;
 				curSymbol[len+1] = '\0';
 			}
-		} 
-		else if (inSymbol && ch == '(') 
+		}
+		else if (inSymbol && ch == '(')
 		{
-			while (++i < strlen(symbols)) 
+			while (++i < strlen(symbols))
 			{
 				ch = symbols[i];
 				if (ch == ')')
@@ -109,34 +107,30 @@ void XkbSymbolParse(const char *symbols, struct _xkb_name *symbolList)
 					}
 				}
 			}
-		} 
-		else 
+		}
+		else
 		{
-			if (inSymbol) 
+			if (inSymbol)
 			{
-				if (isXkbLayoutSymbol(curSymbol)) 
+				if (isXkbLayoutSymbol(curSymbol))
 				{
 					symbolList[curLayout].symbol = (char *)strdup(curSymbol);
 					symbolList[curLayout].variant = (char *)strdup(curVariant);
 					curLayout++;
 				}
-				
-				if (curSymbol != NULL)
-					free(curSymbol);
+
+				free(curSymbol);
 				curSymbol = (char *) malloc (sizeof(char));
-				if (curVariant != NULL)
-					free(curVariant);
-				curVariant = (char *) malloc (sizeof(char));				
+				free(curVariant);
+				curVariant = (char *) malloc (sizeof(char));
 				curSymbol[0] = '\0';
 				curVariant[0] = '\0';
 				inSymbol = 0;
 			}
 		}
 	}
-	if (curSymbol != NULL)
-		free(curSymbol);
-	if (curVariant != NULL)
-		free(curVariant);
+	free(curSymbol);
+	free(curVariant);
 }
 
 char *get_active_kbd_symbol(Display *dpy)
@@ -150,19 +144,17 @@ char *get_active_kbd_symbol(Display *dpy)
 	XkbGetControls(dpy, XkbGroupsWrapMask, desc);
 	XkbGetNames(dpy, XkbGroupNamesMask, desc);
 	XkbGetNames(dpy, XkbSymbolsNameMask, desc);
-	
+
 	struct _xkb_name *xkb_names = (struct _xkb_name *) malloc(sizeof(struct _xkb_name) * desc->ctrls->num_groups);
-	
+
 	XkbSymbolParse(XGetAtomName(dpy, desc->names->symbols), xkb_names);
 	//printf("gxneur active group symbol: %s, variant: %s\n",xkb_names[get_active_kbd_group(dpy)].symbol,xkb_names[get_active_kbd_group(dpy)].variant);
 	char *symbol = strdup(xkb_names[get_active_kbd_group(dpy)].symbol);
-	
+
 	for (int i = 0; i < desc->ctrls->num_groups; i++)
 	{
-		if (xkb_names[i].symbol != NULL)
-			free(xkb_names[i].symbol);
-		if (xkb_names[i].variant != NULL)
-			free(xkb_names[i].variant);
+		free(xkb_names[i].symbol);
+		free(xkb_names[i].variant);
 	}
 	XkbFreeControls(desc, XkbGroupsWrapMask, True);
 	XkbFreeNames(desc, XkbSymbolsNameMask, True);
@@ -180,7 +172,7 @@ int get_active_kbd_group(Display *dpy)
 	return xkbState.group;
 }
 
-int get_kbd_group_count(Display *dpy) 
+int get_kbd_group_count(Display *dpy)
 {
 	if (dpy == NULL)
 		return -1;
@@ -205,7 +197,7 @@ int set_next_kbd_group(Display *dpy)
 		return -1;
 
 	int active_layout_group = get_active_kbd_group(dpy);
-	
+
 	int new_layout_group = active_layout_group + 1;
 	if (new_layout_group == get_kbd_group_count(dpy))
 		new_layout_group = 0;

--- a/kxneur/src/kxneurconf.cpp
+++ b/kxneur/src/kxneurconf.cpp
@@ -538,7 +538,7 @@ KXNeurConf::KXNeurConf(KXNeurApp *app, QWidget *parent)
     abbr_page = new AbbrPage(0, "AbbrPage");
 
     addPage( kxneur_page, i18n("Common"), "keyboard_layout", i18n("Commons Options") ); // or pic = embedjs, exec
-    addPage( xneur_page, i18n("Languages"), "locale", i18n("Languages Options") ); // or pic = 
+    addPage( xneur_page, i18n("Languages"), "locale", i18n("Languages Options") ); // or pic =
     addPage( keys_page, i18n("Keys"), "key_bindings", i18n("Key Combinations") );
     addPage( prog_page, i18n("Programs"), "kwin", i18n("Exclusions for Program") );
     addPage( snd_page, i18n("Sounds"), "kmix", i18n("Sounds for Events") );
@@ -725,15 +725,15 @@ void KXNeurConf::LoadSettings()
 
 void KXNeurConf::SaveSettings()
 {
-    KXNeurSettings::setRunXNeur( 
+    KXNeurSettings::setRunXNeur(
 	kxneur_page->run_xneur->isChecked() );
-    KXNeurSettings::setForceRun( 
+    KXNeurSettings::setForceRun(
 	kxneur_page->force_run->isChecked() );
-    KXNeurSettings::setAutostart( 
+    KXNeurSettings::setAutostart(
 	kxneur_page->autostart->isChecked() );
-    KXNeurSettings::setShowInTray( 
+    KXNeurSettings::setShowInTray(
 	kxneur_page->in_tray->currentItem() );
-    KXNeurSettings::setSwitcherMode( 
+    KXNeurSettings::setSwitcherMode(
 	kxneur_page->sw_mode->isChecked() );
 
     knapp->xnconf->clear(knapp->xnconf);
@@ -829,8 +829,7 @@ void KXNeurConf::SaveSettings()
 	knapp->xnconf->play_sounds = 0;
 
     for ( int i = 0 ; i < MAX_SOUNDS ; i++ ) {
-	if ( knapp->xnconf->sounds[i].file )
-	    free(knapp->xnconf->sounds[i].file);
+	free(knapp->xnconf->sounds[i].file);
 	knapp->xnconf->sounds[i].file = qstrdup(snd_page->edit[i]->text().utf8());
     }
 
@@ -839,20 +838,18 @@ void KXNeurConf::SaveSettings()
     else
 	knapp->xnconf->show_osd = 0;
 
-    if ( knapp->xnconf->osd_font )
-	free(knapp->xnconf->osd_font);
+    free(knapp->xnconf->osd_font);
     knapp->xnconf->osd_font = qstrdup(osd_page->osd_font->text().utf8());
 
     for ( int i = 0 ; i < MAX_OSDS ; i++ ) {
-	if ( knapp->xnconf->osds[i].file )
-	    free(knapp->xnconf->osds[i].file);
+	free(knapp->xnconf->osds[i].file);
 	knapp->xnconf->osds[i].file = qstrdup(osd_page->edit[i]->text().utf8());
     }
 
     if ( abbr_page->ignore_layout->isChecked() )
 	knapp->xnconf->abbr_ignore_layout = 1;
     else
-	knapp->xnconf->abbr_ignore_layout = 0; 
+	knapp->xnconf->abbr_ignore_layout = 0;
 
     knapp->xnconf->save(knapp->xnconf);
     knapp->xnconf->reload(knapp->xnconf);
@@ -910,8 +907,7 @@ void KXNeurConf::KeyToXNConf(int a, int c)
     }
 
     knapp->xnconf->hotkeys[action].modifiers = 0;
-    if ( knapp->xnconf->hotkeys[action].key ) {
-    	free(knapp->xnconf->hotkeys[action].key);
+    free(knapp->xnconf->hotkeys[action].key);
 	knapp->xnconf->hotkeys[action].key = NULL;
     }
 

--- a/kxneur/src/kxnlistbox.cpp
+++ b/kxneur/src/kxnlistbox.cpp
@@ -62,8 +62,7 @@ void KXNListBox::getProgList()
 #endif
 	    prgs << QString::fromLatin1(buf, m-1);
 	pclose(fl);
-	if ( buf )
-	    free(buf);
+	free(buf);
 
 	QString text = KInputDialog::getItem(NULL, i18n("current programs:"), prgs, 0, false, &ok);
 	if ( ok )

--- a/xcurf/src/main.c
+++ b/xcurf/src/main.c
@@ -333,13 +333,14 @@ int main(int argc, char *argv[])
 		char *short_name = strsep(&tmp_symbols, "+");
 		short_name[2] = '\0';
 
+		//FIXME: leak in pixmaps[group]
 		pixmaps[group] = malloc((2 /*language code*/ + 4 /*.png*/ +1 /*\0*/) * sizeof(char));
 		sprintf(pixmaps[group], "%s.png", short_name);
 		pixmaps[group] = get_file_path_name("pixmaps", pixmaps[group]);
 		printf("%s\n", pixmaps[group]);
 	}
 
-	free(symbols);
+	XFree(symbols);
 
 	// Open display
 	display = XOpenDisplay(NULL);

--- a/xneur/lib/ai/detection.c
+++ b/xneur/lib/ai/detection.c
@@ -289,8 +289,7 @@ static int get_similar_words(struct _xneur_handle *handle, struct _buffer *p)
 
 		if (handle->languages[lang].disable_auto_detection || handle->languages[lang].excluded)
 		{
-			if (possible_words != NULL)
-				free (possible_words);
+			free(possible_words);
 			free(word);
 			continue;
 		}
@@ -299,8 +298,7 @@ static int get_similar_words(struct _xneur_handle *handle, struct _buffer *p)
 
 		if ((word_len > 250) || (word_len < 2))
 		{
-			if (possible_words != NULL)
-				free (possible_words);
+			free(possible_words);
 			free(word);
 			continue;
 		}
@@ -319,8 +317,7 @@ static int get_similar_words(struct _xneur_handle *handle, struct _buffer *p)
 
 		if (!handle->has_enchant_checker[lang])
 		{
-			if (possible_words != NULL)
-				free (possible_words);
+			free(possible_words);
 			free(word);
 			continue;
 		}
@@ -334,8 +331,7 @@ static int get_similar_words(struct _xneur_handle *handle, struct _buffer *p)
 				if (tmp_levenshtein < min_levenshtein)
 				{
 					min_levenshtein = tmp_levenshtein;
-					if (possible_words != NULL)
-						free(possible_words);
+					free(possible_words);
 					possible_words = strdup(suggs[i]);
 					possible_lang = lang;
 
@@ -349,19 +345,15 @@ static int get_similar_words(struct _xneur_handle *handle, struct _buffer *p)
 #ifdef WITH_ASPELL
 		if (!handle->has_spell_checker[lang])
 		{
-			if (possible_words != NULL)
-				free (possible_words);
-			if (word != NULL)
-				free(word);
+			free(possible_words);
+			free(word);
 			continue;
 		}
 		const AspellWordList *suggestions = aspell_speller_suggest (handle->spell_checkers[lang], (const char *) word+offset, strlen(word+offset));
 		if (! suggestions)
 		{
-			if (possible_words != NULL)
-				free (possible_words);
-			if (word != NULL)
-				free(word);
+			free(possible_words);
+			free(word);
 			continue;
 		}
 
@@ -374,8 +366,7 @@ static int get_similar_words(struct _xneur_handle *handle, struct _buffer *p)
 			if (tmp_levenshtein < min_levenshtein)
 			{
 				min_levenshtein = tmp_levenshtein;
-				if (possible_words != NULL)
-					free(possible_words);
+				free(possible_words);
 				possible_words = strdup(sugg_word);
 				possible_lang = lang;
 
@@ -398,7 +389,7 @@ static int get_similar_words(struct _xneur_handle *handle, struct _buffer *p)
 
 	log_message(DEBUG, _("   [+] Found suggest word '%s' in %s dictionary (Levenshtein distance = %d)"),
 						possible_words, handle->languages[possible_lang].name, min_levenshtein);
-	free (possible_words);
+	free(possible_words);
 	return possible_lang;
 }
 

--- a/xneur/lib/config/xnconfig.c
+++ b/xneur/lib/config/xnconfig.c
@@ -1263,12 +1263,9 @@ static int xneur_config_get_pid(struct _xneur_config *p)
 	if (getsid(process_id) == -1)
 		return -1;
 
-	char *ps_command = (char *) malloc(1024 * sizeof(char));
-	if (ps_command == NULL)
-		return -1;
-	snprintf(ps_command, 1024, "ps -p %d | grep xneur", process_id);
+	char ps_command[20 + 30];// 20 - length of format string, 30 - more, than maximum length of int in decimal format
+	snprintf(ps_command, sizeof(ps_command)/sizeof(ps_command[0]), "ps -p %d | grep xneur", process_id);
 	FILE *fp = popen(ps_command, "r");
-	free (ps_command);
 	if (fp != NULL)
 	{
 		char buffer[1024];

--- a/xneur/lib/config/xnconfig.c
+++ b/xneur/lib/config/xnconfig.c
@@ -238,8 +238,7 @@ static void parse_line(struct _xneur_config *p, char *line)
 
 	if (param == NULL)
 	{
-		if (full_string != NULL)
-			free(full_string);
+		free(full_string);
 		log_message(WARNING, _("Param mismatch for option %s"), option);
 		return;
 	}
@@ -585,8 +584,7 @@ static void parse_line(struct _xneur_config *p, char *line)
 				cmd = strstr(cmd + strlen(USR_CMD_START)*sizeof(char), USR_CMD_END);
 				if (cmd == NULL)
 				{
-					if (new_user_action->command != NULL)
-						free(new_user_action->command);
+					free(new_user_action->command);
 					new_user_action->command = NULL;
 					break;
 				}
@@ -1130,22 +1128,16 @@ static void free_structures(struct _xneur_config *p)
 
 	for (int notify = 0; notify < MAX_NOTIFIES; notify++)
 	{
-		if (p->sounds[notify].file != NULL)
-			free(p->sounds[notify].file);
-
-		if (p->osds[notify].file != NULL)
-			free(p->osds[notify].file);
-
-		if (p->popups[notify].file != NULL)
-			free(p->popups[notify].file);
+		free(p->sounds[notify].file);
+		free(p->osds[notify].file);
+		free(p->popups[notify].file);
 	}
 
 	if (p->actions != NULL)
 	{
 		for (int action = 0; action < p->actions_count; action++)
 		{
-			if (p->actions[action].hotkey.key != NULL)
-				free(p->actions[action].hotkey.key);
+			free(p->actions[action].hotkey.key);
 		}
 	}
 
@@ -1153,12 +1145,9 @@ static void free_structures(struct _xneur_config *p)
 	{
 		for (int action = 0; action < p->user_actions_count; action++)
 		{
-			if (p->user_actions[action].hotkey.key != NULL)
-				free(p->user_actions[action].hotkey.key);
-			if (p->user_actions[action].name != NULL)
-				free(p->user_actions[action].name);
-			if (p->user_actions[action].command != NULL)
-				free(p->user_actions[action].command);
+			free(p->user_actions[action].hotkey.key);
+			free(p->user_actions[action].name);
+			free(p->user_actions[action].command);
 		}
 	}
 
@@ -1170,17 +1159,10 @@ static void free_structures(struct _xneur_config *p)
 	memset(p->popups, 0, MAX_NOTIFIES * sizeof(struct _xneur_notify));
 
 
-	if (p->version != NULL)
-		free(p->version);
-
-	if (p->osd_font != NULL)
-		free(p->osd_font);
-
-	//if (p->actions != NULL)
-	//	free(p->actions);
-
-	//if (p->user_actions != NULL)
-	//	free(p->user_actions);
+	free(p->version);
+	free(p->osd_font);
+	//free(p->actions);
+	//free(p->user_actions);
 }
 
 static void xneur_config_reload(struct _xneur_config *p)
@@ -1764,8 +1746,7 @@ static void xneur_config_save_dict(struct _xneur_config *p, int lang)
 	char *lang_dir = (char *) malloc(path_len * sizeof(char));
 	snprintf(lang_dir, path_len, "%s/%s", LANGUAGEDIR, p->handle->languages[lang].dir);
 	save_list(p->handle->languages[lang].dictionary, lang_dir, DICT_NAME);
-	if (lang_dir != NULL)
-		free (lang_dir);
+	free(lang_dir);
 }
 
 static void xneur_config_save_pattern(struct _xneur_config *p, int lang)
@@ -1779,8 +1760,7 @@ static void xneur_config_save_pattern(struct _xneur_config *p, int lang)
 	char *lang_dir = (char *) malloc(path_len * sizeof(char));
 	snprintf(lang_dir, path_len, "%s/%s", LANGUAGEDIR, p->handle->languages[lang].dir);
 	save_list(p->handle->languages[lang].pattern, lang_dir, PATTERN_NAME);
-	if (lang_dir != NULL)
-		free(lang_dir);
+	free(lang_dir);
 }
 
 static const char* xneur_config_get_log_level_name(struct _xneur_config *p)
@@ -1802,16 +1782,12 @@ static void xneur_config_uninit(struct _xneur_config *p)
 	free(p->osds);
 	free(p->popups);
 
-	if (p->delimeters != NULL)
-		free(p->delimeters);
-	if (p->delimeters_string != NULL)
-		free(p->delimeters_string);
+	free(p->delimeters);
+	free(p->delimeters_string);
 	p->delimeters_count = 0;
 
-	if (p->mail_keyboard_log != NULL)
-		free(p->mail_keyboard_log);
-	if (p->host_keyboard_log != NULL)
-		free(p->host_keyboard_log);
+	free(p->mail_keyboard_log);
+	free(p->host_keyboard_log);
 
 	xneur_handle_destroy(p->handle);
 

--- a/xneur/lib/lib/xneurlib.c
+++ b/xneur/lib/lib/xneurlib.c
@@ -256,9 +256,6 @@ struct _xneur_handle *xneur_handle_create (void)
 		handle->languages[handle->total_languages].disable_auto_detection	= FALSE;
 		handle->total_languages++;
 
-		//if (group_name != NULL)
-			//free(group_name);
-
 		if (prop_value == NULL)
 			break;
 		function_end:;
@@ -446,28 +443,22 @@ void xneur_handle_destroy (struct _xneur_handle *handle)
 		if (handle->languages[lang].pattern != NULL)
 			handle->languages[lang].pattern->uninit(handle->languages[lang].pattern);
 
-		if (handle->languages[lang].name != NULL)
-			free(handle->languages[lang].name);
-		if (handle->languages[lang].dir != NULL)
-			free(handle->languages[lang].dir);
+		free(handle->languages[lang].name);
+		free(handle->languages[lang].dir);
 	}
 	handle->total_languages = 0;
 	free(handle->languages);
 
 #ifdef WITH_ASPELL
 	delete_aspell_config(handle->spell_config);
-	if (handle->spell_checkers != NULL)
-		free(handle->spell_checkers);
-	if (handle->has_spell_checker != NULL)
-		free(handle->has_spell_checker);
+	free(handle->spell_checkers);
+	free(handle->has_spell_checker);
 #endif
 
 #ifdef WITH_ENCHANT
 	enchant_broker_free (handle->enchant_broker);
-	if (handle->enchant_dicts != NULL)
-		free(handle->enchant_dicts);
-	if (handle->has_enchant_checker != NULL)
-		free(handle->has_enchant_checker);
+	free(handle->enchant_dicts);
+	free(handle->has_enchant_checker);
 #endif
 
 	free(handle);

--- a/xneur/lib/main/bind_table.c
+++ b/xneur/lib/main/bind_table.c
@@ -125,8 +125,7 @@ static void bind_action(enum _hotkey_action action)
 		log_message(ERROR, _("      KeySym (or with Shift modifier) is undefined!"), _(normal_action_names[action]), key);
 
 	}
-	if (key != NULL)
-		free(key);
+	free(key);
 }
 
 static void bind_user_action(int action)
@@ -165,8 +164,7 @@ static void bind_user_action(int action)
 		log_message(ERROR, _("      KeySym (or with Shift modifier) is undefined!"));
 
 	}
-	if (key != NULL)
-		free(key);
+	free(key);
 }
 
 enum _hotkey_action get_action(KeySym key_sym, int mask)
@@ -226,8 +224,7 @@ void bind_actions(void)
 
 void unbind_actions(void)
 {
-	if (btable != NULL)
-		free(btable);
+	free(btable);
 	btable = NULL;
 }
 
@@ -287,8 +284,7 @@ void bind_user_actions(void)
 
 void unbind_user_actions(void)
 {
-	if (ubtable != NULL)
-		free(ubtable);
+	free(ubtable);
 	ubtable = NULL;
 }
 

--- a/xneur/lib/main/buffer.c
+++ b/xneur/lib/main/buffer.c
@@ -653,25 +653,18 @@ static void buffer_uninit(struct _buffer *p)
 	if (p == NULL)
 		return;
 
-	if (p->keycode_modifiers != NULL)
-		free(p->keycode_modifiers);
-	if (p->keycode != NULL)
-		free(p->keycode);
-	if (p->content != NULL)
-		free(p->content);
+	free(p->keycode_modifiers);
+	free(p->keycode);
+	free(p->content);
 
 	if (p->i18n_content != NULL)
 	{
 		for (int i = 0; i < p->handle->total_languages; i++)
 		{
-			if (p->i18n_content[i].content != NULL)
-				free(p->i18n_content[i].content);
-			if (p->i18n_content[i].symbol_len != NULL)
-				free(p->i18n_content[i].symbol_len);
-			if (p->i18n_content[i].content_unchanged != NULL)
-				free(p->i18n_content[i].content_unchanged);
-			if (p->i18n_content[i].symbol_len_unchanged != NULL)
-				free(p->i18n_content[i].symbol_len_unchanged);
+			free(p->i18n_content[i].content);
+			free(p->i18n_content[i].symbol_len);
+			free(p->i18n_content[i].content_unchanged);
+			free(p->i18n_content[i].symbol_len_unchanged);
 		}
 
 		free(p->i18n_content);

--- a/xneur/lib/main/event.c
+++ b/xneur/lib/main/event.c
@@ -165,8 +165,7 @@ void event_send_xkey(struct _event *p, KeyCode kc, int modifiers)
 		XSendEvent(main_window->display, p->owner_window, TRUE, NoEventMask, &p->event);
 		XFlush(main_window->display);
 		log_message(TRACE, _("The event KeyRelease is not sent to the window (ID %d) with name '%s'"), p->owner_window, app_name);
-		if (app_name != NULL)
-			free(app_name);
+		free(app_name);
 		return;
 	}
 
@@ -186,8 +185,7 @@ void event_send_xkey(struct _event *p, KeyCode kc, int modifiers)
 	XSendEvent(main_window->display, p->owner_window, TRUE, NoEventMask, &p->event);
 	XFlush(main_window->display);
 
-	if (app_name != NULL)
-		free(app_name);
+	free(app_name);
 }
 
 static void common_send_xkey(struct _event *p, int count, int input_keycode, int Mask_modifier)
@@ -281,8 +279,7 @@ static void event_send_next_event(struct _event *p)
 
 static void event_uninit(struct _event *p)
 {
-	if (p != NULL)
-		free(p);
+	free(p);
 
 	log_message(DEBUG, _("Event is freed"));
 }

--- a/xneur/lib/main/focus.c
+++ b/xneur/lib/main/focus.c
@@ -139,8 +139,7 @@ static int get_focus(struct _focus *p, int *forced_mode, int *focus_status, int 
 	Window old_window = p->owner_window;
 	if (new_window == old_window)
 	{
-		if (new_app_name != NULL)
-			free(new_app_name);
+		free(new_app_name);
 		if (xconfig->troubleshoot_full_screen)
 		{
 			Window root_return;
@@ -199,8 +198,7 @@ static int get_focus(struct _focus *p, int *forced_mode, int *focus_status, int 
 
 	log_message(DEBUG, _("Process new window (ID %d) with name '%s' (status %s, mode %s)"), new_window, new_app_name, _(verbose_focus_status[*focus_status]), _(verbose_forced_mode[*forced_mode]));
 
-	if (new_app_name != NULL)
-		free(new_app_name);
+	free(new_app_name);
 	return FOCUS_CHANGED;
 }
 
@@ -262,14 +260,12 @@ static void focus_update_grab_events(struct _focus *p, int mode)
 
 	p->last_parent_window = p->parent_window;
 
-	if (owner_window_name != NULL)
-		free(owner_window_name);
+	free(owner_window_name);
 }
 
 static void focus_uninit(struct _focus *p)
 {
-	if (p != NULL)
-		free(p);
+	free(p);
 
 	log_message(DEBUG, _("Focus is freed"));
 }

--- a/xneur/lib/main/keymap.c
+++ b/xneur/lib/main/keymap.c
@@ -166,8 +166,7 @@ static char* keymap_keycode_to_symbol(struct _keymap *p, KeyCode kc, int group, 
 	pr = p->keycode_to_symbol_cache + p->keycode_to_symbol_cache_pos;
 
 	pr->symbol_size = (strlen(symbol) + 1) * sizeof(char);
-	if (pr->symbol)
-		free(pr->symbol);
+	free(pr->symbol);
 	pr->symbol = symbol;
 	pr->kc     = kc;
 	pr->group  = group;
@@ -454,19 +453,17 @@ static void keymap_purge_caches(struct _keymap *p)
 	for (int i = 0; i < keycode_to_symbol_cache_size; i++)
 	{
 		struct keycode_to_symbol_pair* pr = p->keycode_to_symbol_cache + i;
-		if (pr->symbol)
-			free(pr->symbol),
-			pr->symbol = NULL,
-			pr->symbol_size = 0;
+		free(pr->symbol);
+		pr->symbol = NULL;
+		pr->symbol_size = 0;
 	}
 
 	for (int i = 0; i < symbol_to_keycode_cache_size; i++)
 	{
 		struct symbol_to_keycode_pair* pr = p->symbol_to_keycode_cache + i;
-		if (pr->symbol)
-			free(pr->symbol),
-			pr->symbol = NULL,
-			pr->symbol_size = 0;
+		free(pr->symbol);
+		pr->symbol = NULL;
+		pr->symbol_size = 0;
 	}
 
 }

--- a/xneur/lib/main/program.c
+++ b/xneur/lib/main/program.c
@@ -255,52 +255,39 @@ static void program_layout_update(struct _program *p)
 	if ((Window) p->last_window == p->focus->owner_window)
 		return;
 
-	char *text_to_find	= (char *) malloc(1024 * sizeof(char));
-	if (text_to_find == NULL)
-		return;
-	char *window_layouts	= (char *) malloc(1024 * sizeof(char));
-	if (window_layouts == NULL)
-	{
-		free(text_to_find);
-		return;
-	}
+	char text_to_find[1024];
+	char window_layout[1024];
 
 	fetch_window_name(text_to_find, p->last_window);
 	// Remove layout for old window
 	for (int lang = 0; lang < xconfig->handle->total_languages; lang++)
 	{
-		sprintf(window_layouts, "%s %d", text_to_find, lang);
+		sprintf(window_layout, "%s %d", text_to_find, lang);
 
-		if (!xconfig->window_layouts->exist(xconfig->window_layouts, window_layouts, BY_PLAIN))
+		if (!xconfig->window_layouts->exist(xconfig->window_layouts, window_layout, BY_PLAIN))
 			continue;
 
-		xconfig->window_layouts->rem(xconfig->window_layouts, window_layouts);
+		xconfig->window_layouts->rem(xconfig->window_layouts, window_layout);
 	}
 
 	// Save layout for old window
-	sprintf(window_layouts, "%s %d", text_to_find, p->last_layout);
-	xconfig->window_layouts->add(xconfig->window_layouts, window_layouts);
+	sprintf(window_layout, "%s %d", text_to_find, p->last_layout);
+	xconfig->window_layouts->add(xconfig->window_layouts, window_layout);
 
 	fetch_window_name(text_to_find, p->focus->owner_window);
 
 	// Restore layout for new window
 	for (int lang = 0; lang < xconfig->handle->total_languages; lang++)
 	{
-		sprintf(window_layouts, "%s %d", text_to_find, lang);
-		if (!xconfig->window_layouts->exist(xconfig->window_layouts, window_layouts, BY_PLAIN))
+		sprintf(window_layout, "%s %d", text_to_find, lang);
+		if (!xconfig->window_layouts->exist(xconfig->window_layouts, window_layout, BY_PLAIN))
 			continue;
-
-		free(text_to_find);
-		free(window_layouts);
 
 		//XkbLockGroup(main_window->display, XkbUseCoreKbd, lang);
 		set_keyboard_group(lang);
 		log_message(DEBUG, _("Restore layout group to %d"), lang);
 		return;
 	}
-
-	free(text_to_find);
-	free(window_layouts);
 
 	log_message(DEBUG, _("Store default layout group to %d"), xconfig->default_group);
 }
@@ -1344,10 +1331,8 @@ static int program_perform_action(struct _program *p, enum _hotkey_action action
 			if (loctime == NULL)
 				break;
 
-			char *date = malloc(256 * sizeof(char));
-			if (date == NULL)
-				break;
-			strftime(date, 256, "%x", loctime);
+			char date[32];
+			strftime(date, sizeof(date)/sizeof(date[0]), "%x", loctime);
 
 			// Insert Date
 			log_message(DEBUG, _("Insert date '%s'."), date);
@@ -1360,8 +1345,6 @@ static int program_perform_action(struct _program *p, enum _hotkey_action action
 			p->correction_buffer->clear(p->correction_buffer);
 
 			p->event->default_event.xkey.keycode = 0;
-
-			free (date);
 			break;
 		}
 		case ACTION_REPLACE_ABBREVIATION: // User needs to replace acronym

--- a/xneur/lib/main/program.c
+++ b/xneur/lib/main/program.c
@@ -1717,9 +1717,6 @@ static void program_check_ellipsis(struct _program *p)
 		return;
 
 	char *text = p->buffer->get_utf_string(p->buffer);
-	if (text == NULL)
-		return;
-
 	int text_len = strlen(text);
 
 	if ((text[text_len-1] != '.') ||
@@ -1749,9 +1746,6 @@ static void program_check_space_before_punctuation(struct _program *p)
 		return;
 
 	char *text = p->buffer->get_utf_string(p->buffer);
-	if (text == NULL)
-		return;
-
 	if (p->buffer->cur_pos < 3)
 	{
 		free(text);
@@ -1797,9 +1791,6 @@ static void program_check_space_with_bracket(struct _program *p)
 		return;
 
 	char *text = p->buffer->get_utf_string(p->buffer);
-	if (text == NULL)
-		return;
-
 	if (p->buffer->cur_pos < 3)
 	{
 		free(text);

--- a/xneur/lib/main/program.c
+++ b/xneur/lib/main/program.c
@@ -705,8 +705,7 @@ static void program_process_selection_notify(struct _program *p)
 		convert_text_to_translit(&event_text);
 
 	p->buffer->set_content(p->buffer, event_text);
-	if (event_text != NULL)
-		free(event_text);
+	free(event_text);
 
 	switch (p->action_mode)
 	{
@@ -763,8 +762,7 @@ static void program_process_selection_notify(struct _program *p)
 
 			char *string = p->buffer->get_utf_string(p->buffer);
 			show_notify(NOTIFY_PREVIEW_CHANGE_SELECTED, string);
-			if (string)
-				free (string);
+			free(string);
 			break;
 		}
 		case ACTION_PREVIEW_CHANGE_CLIPBOARD:
@@ -773,8 +771,7 @@ static void program_process_selection_notify(struct _program *p)
 
 			char *string = p->buffer->get_utf_string(p->buffer);
 			show_notify(NOTIFY_PREVIEW_CHANGE_CLIPBOARD, string);
-			if (string)
-				free (string);
+			free(string);
 			break;
 		}
 	}
@@ -1356,8 +1353,7 @@ static int program_perform_action(struct _program *p, enum _hotkey_action action
 			char *word = p->buffer->get_last_word(p->buffer, utf_string);
 			if (!word)
 			{
-				if (utf_string != NULL)
-					free(utf_string);
+				free(utf_string);
 				return FALSE;
 			}
 
@@ -1368,8 +1364,7 @@ static int program_perform_action(struct _program *p, enum _hotkey_action action
 
 				if (string == NULL)
 				{
-					if (replacement != NULL)
-						free(replacement);
+					free(replacement);
 					continue;
 				}
 
@@ -1414,13 +1409,11 @@ static int program_perform_action(struct _program *p, enum _hotkey_action action
 				p->event->default_event.xkey.keycode = 0;
 
 				free(replacement);
-				if (utf_string != NULL)
-					free(utf_string);
+				free(utf_string);
 				return TRUE;
 			}
 
-			if (utf_string != NULL)
-				free(utf_string);
+			free(utf_string);
 			return FALSE;
 		}
 	}
@@ -1924,7 +1917,7 @@ static void program_check_brackets_with_symbols(struct _program *p)
 	if (pos < 0 || text[pos] != '(')
 	{
 		free(text);
-	    return;
+		return;
 	}
 
 	log_message(DEBUG, _("Find spaces after left bracket, correction..."));
@@ -1981,11 +1974,11 @@ static void program_check_capital_letter_after_dot(struct _program *p)
 		case ',':
 		case '.':
 		{
-			free (symbol);
+			free(symbol);
 			return;
 		}
 	}
-	free (symbol);
+	free(symbol);
 
 	char *text = strdup(p->buffer->content);
 	if (text == NULL)
@@ -1997,7 +1990,7 @@ static void program_check_capital_letter_after_dot(struct _program *p)
 		free(text);
 		return;
 	}
-	free (text);
+	free(text);
 
 	text = p->buffer->get_utf_string_on_kbd_group(p->buffer, get_curr_keyboard_group());
 	if (text == NULL)
@@ -2045,7 +2038,7 @@ static void program_check_pattern(struct _program *p)
 	int len = trim_word(word, strlen(tmp));
 	if (len == 0)
 	{
-		free (word);
+		free(word);
 		return;
 	}
 
@@ -2074,7 +2067,7 @@ static void program_check_pattern(struct _program *p)
 	if (pattern_data == NULL)
 	{
 		p->last_action = ACTION_NONE;
-		free (word);
+		free(word);
 		return;
 	}
 
@@ -2088,7 +2081,7 @@ static void program_check_pattern(struct _program *p)
 	{
 		tmp_buffer->uninit(tmp_buffer);
 		p->last_action = ACTION_NONE;
-		free (word);
+		free(word);
 		return;
 	}
 
@@ -2105,7 +2098,7 @@ static void program_check_pattern(struct _program *p)
 	p->last_action = ACTION_AUTOCOMPLETION;
 	p->last_pattern_id = 0;
 
-	free (word);
+	free(word);
 }
 
 static void program_rotate_pattern(struct _program *p)
@@ -2136,14 +2129,14 @@ static void program_rotate_pattern(struct _program *p)
 	int len = trim_word(word, strlen(tmp));
 	if (len == 0)
 	{
-		free (word);
+		free(word);
 		return;
 	}
 
 	struct _list_char* list_alike = xconfig->handle->languages[lang].pattern->alike(xconfig->handle->languages[lang].pattern, word);
 	if (list_alike == NULL)
 	{
-		free (word);
+		free(word);
 		return;
 	}
 
@@ -2156,7 +2149,7 @@ static void program_rotate_pattern(struct _program *p)
 	{
 		list_alike->uninit(list_alike);
 		list_alike  =  NULL;
-		free (word);
+		free(word);
 		return;
 	}
 
@@ -2175,7 +2168,7 @@ static void program_rotate_pattern(struct _program *p)
 		list_alike->uninit(list_alike);
 		tmp_buffer->uninit(tmp_buffer);
 		p->last_action = ACTION_NONE;
-		free (word);
+		free(word);
 		return;
 	}
 
@@ -2191,7 +2184,7 @@ static void program_rotate_pattern(struct _program *p)
 
 	p->last_action = ACTION_AUTOCOMPLETION;
 
-	free (word);
+	free(word);
 
 	list_alike->uninit(list_alike);
 	list_alike  =  NULL;
@@ -2341,8 +2334,7 @@ static void program_check_misprint(struct _program *p)
 		if (possible_word == NULL)
 			possible_word = first_sugg;
 		else
-			if (first_sugg != NULL)
-				free(first_sugg);
+			free(first_sugg);
 	}
 
 
@@ -2414,8 +2406,7 @@ static void program_check_misprint(struct _program *p)
 		char *notify_text = (char *) malloc(notify_text_len * sizeof(char));
 		snprintf(notify_text , notify_text_len, _("Correction '%s' to '%s'"), word+offset, possible_word);
 		show_notify(NOTIFY_CORR_MISPRINT, notify_text);
-		if (notify_text != NULL)
-			free(notify_text);
+		free(notify_text);
 
 		p->correction_action = CORRECTION_MISPRINT;
 		//p->buffer->save_and_clear(p->buffer, p->focus->owner_window);
@@ -2737,8 +2728,7 @@ static void program_change_word(struct _program *p, enum _change_action action)
 			convert_text_to_translit(&text);
 			p->buffer->set_content(p->buffer, text);
 
-			if (text != NULL)
-				free(text);
+			free(text);
 
 			int len = p->buffer->cur_pos;
 			if (p->last_action == ACTION_AUTOCOMPLETION)
@@ -2783,8 +2773,7 @@ static void program_change_word(struct _program *p, enum _change_action action)
 
 			char *string = p->buffer->get_utf_string(p->buffer);
 			show_notify(NOTIFY_MANUAL_PREVIEW_CHANGE_WORD, string);
-			if (string != NULL)
-				free(string);
+			free(string);
 			p->buffer->unset_offset(p->buffer, offset);
 
 			break;
@@ -3085,7 +3074,7 @@ static void program_add_word_to_pattern(struct _program *p, int new_lang)
 		len = trim_word(old_word, strlen(tmp));
 		if (len == 0)
 		{
-			free (old_word);
+			free(old_word);
 			continue;
 		}
 		unsigned int offset = 0;
@@ -3102,7 +3091,7 @@ static void program_add_word_to_pattern(struct _program *p, int new_lang)
 			old_pattern->rem(old_pattern, old_word+offset);
 			xconfig->save_pattern(xconfig, i);
 		}
-		free (old_word);
+		free(old_word);
 	}
 
 #ifdef WITH_ASPELL

--- a/xneur/lib/main/program.c
+++ b/xneur/lib/main/program.c
@@ -2078,12 +2078,12 @@ static void program_check_pattern(struct _program *p)
 	struct _buffer *tmp_buffer = buffer_init(xconfig->handle, main_window->keymap);
 
 	tmp_buffer->set_content(tmp_buffer, pattern_data->string + strlen(word)*sizeof(char));
+	free(word);
 
 	if (tmp_buffer->cur_pos == 0)
 	{
 		tmp_buffer->uninit(tmp_buffer);
 		p->last_action = ACTION_NONE;
-		free(word);
 		return;
 	}
 
@@ -2099,8 +2099,6 @@ static void program_check_pattern(struct _program *p)
 
 	p->last_action = ACTION_AUTOCOMPLETION;
 	p->last_pattern_id = 0;
-
-	free(word);
 }
 
 static void program_rotate_pattern(struct _program *p)
@@ -2165,12 +2163,13 @@ static void program_rotate_pattern(struct _program *p)
 
 	tmp_buffer->set_content(tmp_buffer, list_alike->data[p->last_pattern_id].string + strlen(word)*sizeof(char));
 
+	free(word);
+	list_alike->uninit(list_alike);
+
 	if (tmp_buffer->cur_pos == 0)
 	{
-		list_alike->uninit(list_alike);
 		tmp_buffer->uninit(tmp_buffer);
 		p->last_action = ACTION_NONE;
-		free(word);
 		return;
 	}
 
@@ -2185,11 +2184,6 @@ static void program_rotate_pattern(struct _program *p)
 	tmp_buffer->uninit(tmp_buffer);
 
 	p->last_action = ACTION_AUTOCOMPLETION;
-
-	free(word);
-
-	list_alike->uninit(list_alike);
-	list_alike  =  NULL;
 }
 
 static void program_check_misprint(struct _program *p)

--- a/xneur/lib/misc/debug.c
+++ b/xneur/lib/misc/debug.c
@@ -32,7 +32,7 @@
 
 static struct _list_char *allocates = NULL;
 
-static const int pointer_len = sizeof(void *) * 2 + 3; // + 0x + NULLSYM
+static const int POINTER_LEN = sizeof(void *) * 2 + 3; // + 0x + NULLSYM
 
 void xndebug_init(void)
 {
@@ -48,17 +48,12 @@ void* xndebug_malloc(int len, char *file, int line)
 
 	void *mem = malloc(len);
 
-	char *pointer = (char *) malloc(pointer_len * sizeof(char));
+	char pointer[POINTER_LEN];
 	sprintf(pointer, "%p", mem);
-
-	//log_message(TRACE, _("Allocating memory pointer %p (at %s:%d)"), mem, file, line);
 
 	struct _list_char_data *data = allocates->add(allocates, pointer);
 	data->debug_value = line;
 	data->debug_string = file;
-
-	free(pointer);
-
 	return mem;
 }
 
@@ -68,16 +63,12 @@ void* xndebug_calloc(int n, int size, char *file, int line)
 
 	void *mem = calloc(n, size);
 
-	char *pointer = (char *) malloc(pointer_len * sizeof(char));
+	char pointer[POINTER_LEN];
 	sprintf(pointer, "%p", mem);
-
-	//log_message(TRACE, _("Callocating memory pointer %p (at %s:%d)"), mem, file, line);
 
 	struct _list_char_data *data = allocates->add(allocates, pointer);
 	data->debug_value = line;
 	data->debug_string = file;
-
-	free(pointer);
 
 	return mem;
 }	
@@ -86,17 +77,13 @@ void xndebug_free(void *mem, char *file, int line)
 {
 	xndebug_init();
 
-	char *pointer = (char *) malloc(pointer_len * sizeof(char));
+	char pointer[POINTER_LEN];
 	sprintf(pointer, "%p", mem);
 
 	if (!allocates->exist(allocates, pointer, BY_PLAIN))
 		log_message(ERROR, _("Freeing invalid memory pointer %p (at %s:%d)"), mem, file, line);
-	//else
-		//log_message(TRACE, _("Freeing memory pointer %p (at %s:%d)"), mem, file, line);
 
 	allocates->rem(allocates, pointer);
-
-	free(pointer);
 
 	free(mem);
 }
@@ -107,16 +94,12 @@ char* xndebug_strdup(const char *str, char *file, int line)
 
 	char *mem = strdup(str);
 
-	char *pointer = (char *) malloc(pointer_len * sizeof(char));
+	char pointer[POINTER_LEN];
 	sprintf(pointer, "%p", mem);
-
-	//log_message(TRACE, _("Duping memory pointer %p (at %s:%d)"), mem, file, line);
 
 	struct _list_char_data *data = allocates->add(allocates, pointer);
 	data->debug_value = line;
 	data->debug_string = file;
-
-	free(pointer);
 
 	return mem;
 }
@@ -125,7 +108,7 @@ void* xndebug_realloc(void *mem, int len, char *file, int line)
 {
 	xndebug_init();
 
-	char *pointer = (char *) malloc(pointer_len * sizeof(char));
+	char pointer[POINTER_LEN];
 
 	if (mem != NULL)
 	{
@@ -133,8 +116,6 @@ void* xndebug_realloc(void *mem, int len, char *file, int line)
 
 		if (!allocates->exist(allocates, pointer, BY_PLAIN))
 			log_message(ERROR, _("Reallocating invalid memory pointer %p (at %s:%d)"), mem, file, line);
-		//else
-			//log_message(TRACE, _("Freeing memory pointer %p (at %s:%d)"), mem, file, line);
 		allocates->rem(allocates, pointer);
 	}
 
@@ -144,14 +125,10 @@ void* xndebug_realloc(void *mem, int len, char *file, int line)
 	{
 		sprintf(pointer, "%p", new_mem);
 
-		//log_message(TRACE, _("Allocating memory pointer %p (at %s:%d)"), new_mem, file, line);
-
 		struct _list_char_data *data = allocates->add(allocates, pointer);
 		data->debug_value = line;
 		data->debug_string = file;
 	}
-
-	free(pointer);
 
 	return new_mem;
 }

--- a/xneur/lib/misc/debug.c
+++ b/xneur/lib/misc/debug.c
@@ -71,10 +71,12 @@ void* xndebug_calloc(int n, int size, char *file, int line)
 	data->debug_string = file;
 
 	return mem;
-}	
+}
 
 void xndebug_free(void *mem, char *file, int line)
 {
+	if (mem == NULL) return;
+
 	xndebug_init();
 
 	char pointer[POINTER_LEN];

--- a/xneur/lib/misc/log.c
+++ b/xneur/lib/misc/log.c
@@ -79,23 +79,12 @@ void log_message(int level, const char *string, ...)
 
 	time_t curtime = time(NULL);
 	struct tm *loctime = localtime(&curtime);
-	char *time_buffer = NULL; 
-	if (loctime != NULL)
-	{
-		char *tb = malloc(256 * sizeof(char));
-		strftime(tb, 256, "%T", loctime);
-		time_buffer = malloc((strlen(tb) + 1) * sizeof(char));
-		time_buffer[0] = 0;
-		sprintf(time_buffer, "%s ", tb);
-		free(tb);
-	}
-
-	if (time_buffer == NULL)
-	{
-		time_buffer = malloc(sizeof(char));
-		time_buffer[0] = 0;
-	}
-	int len = strlen(string) + strlen(modifier) + strlen(time_buffer) + 3;
+	char time_buffer[64];
+	time_buffer[0] = 0;
+	size_t time_len = loctime != NULL
+		? strftime(time_buffer, sizeof(time_buffer)/sizeof(time_buffer[0]), "%T ", loctime)
+		: 0;
+	int len = strlen(modifier) + time_len + strlen(string) + 2;// \n + \0
 
 	char *buffer = (char *) malloc(len + 1);
 	snprintf(buffer, len, "%s%s%s\n", modifier, time_buffer, string);
@@ -107,6 +96,5 @@ void log_message(int level, const char *string, ...)
 	vfprintf(stream, buffer, ap);
 
 	free(buffer);
-	free(time_buffer);
 	va_end(ap);
 }

--- a/xneur/lib/misc/text.c
+++ b/xneur/lib/misc/text.c
@@ -134,9 +134,8 @@ char* str_replace(const char *source, const char *search, const char *replace)
 
 	size_t avail_space = source_len * max_multiplier;
 	char *result = (char *) malloc((avail_space + 1) * sizeof(char));
-	result[0] = NULLSYM;
+	result[0] = '\0';
 
-	char *result_orig = result;
 	while (TRUE)
 	{
 		char *found = strstr(source, search);
@@ -158,7 +157,7 @@ char* str_replace(const char *source, const char *search, const char *replace)
 		avail_space -= replace_len;
 	}
 
-	return result_orig;
+	return result;
 }
 
 char* real_sym_to_escaped_sym(const char *source)
@@ -171,16 +170,14 @@ char* real_sym_to_escaped_sym(const char *source)
 	if (dummy != NULL)
 	{
 		free(string);
-		string = strdup(dummy);
-		free(dummy);
+		string = dummy;
 	}
 
 	dummy = str_replace(string, "\t", "\\t");
 	if (dummy != NULL)
 	{
 		free(string);
-		string = strdup(dummy);
-		free(dummy);
+		string = dummy;
 	}
 
 	dummy = str_replace(string, "\n", "\\n");
@@ -195,26 +192,21 @@ char* escaped_sym_to_real_sym(const char *source)
 		return NULL;
 
 	// Replace escaped-symbols
-	char escape[] = {'\n', NULLSYM};
-	char *dummy = str_replace(string, "\\n", escape);
+	char *dummy = str_replace(string, "\\n", "\n");
 	if (dummy != NULL)
 	{
 		free(string);
-		string = strdup(dummy);
-		free(dummy);
+		string = dummy;
 	}
 
-	escape[0] = '\t';
-	dummy = str_replace(string, "\\t", escape);
+	dummy = str_replace(string, "\\t", "\t");
 	if (dummy != NULL)
 	{
 		free(string);
-		string = strdup(dummy);
-		free(dummy);
+		string = dummy;
 	}
 
-	escape[0] = '\\';
-	dummy = str_replace(string, "\\\\", escape);
+	dummy = str_replace(string, "\\\\", "\\");
 	free(string);
 	return dummy;
 }

--- a/xneur/lib/notify/osd.c
+++ b/xneur/lib/notify/osd.c
@@ -102,7 +102,6 @@ void osd_show(int notify, char *command)
 	pthread_create(&osd_thread, &osd_thread_attr, (void *) &osd_show_thread, osd_text);
 
 	pthread_attr_destroy(&osd_thread_attr);
-	free(osd_text);
 }
 
 #else /* WITH_XOSD */

--- a/xneur/lib/notify/popup.c
+++ b/xneur/lib/notify/popup.c
@@ -58,7 +58,7 @@ void popup_init(void)
 		return;
 
 	notify_init("xneur");
-	
+
 }
 
 void popup_uninit(void)
@@ -76,13 +76,13 @@ static void popup_show_thread(struct _popup_body *popup_body)
 		popup_body->header = popup_body->content;
 		popup_body->content = NULL;
 	}
-	
+
 #if NOTIFY_CHECK_VERSION(0,7,0)
 	NotifyNotification *notify = notify_notification_new(popup_body->header, popup_body->content, icon);
 #else
  	NotifyNotification *notify = notify_notification_new(popup_body->header, popup_body->content, icon, NULL);
 #endif
-		
+
 	notify_notification_set_category(notify, type);
 	notify_notification_set_urgency(notify, urgency);
 	notify_notification_set_timeout(notify, xconfig->popup_expire_timeout);
@@ -90,11 +90,9 @@ static void popup_show_thread(struct _popup_body *popup_body)
 
 	notify_notification_show(notify, NULL);
 
-	if (popup_body->header != NULL)
-		free(popup_body->header);
-	if (popup_body->content != NULL)
-		free(popup_body->content);
-	free (popup_body);
+	free(popup_body->header);
+	free(popup_body->content);
+	free(popup_body);
 
 	notify_notification_clear_actions(notify);
 
@@ -102,26 +100,26 @@ static void popup_show_thread(struct _popup_body *popup_body)
 }
 
 void popup_show(int notify, char *command)
-{	
+{
 	if (!xconfig->show_popup)
 		return;
-	
+
 	if ((xconfig->popups[notify].file == NULL) && (command == NULL))
 		return;
 
 	if (!xconfig->popups[notify].enabled)
 		return;
-	
+
 	time_t curtime = time(NULL);
 	if ((curtime - timestamp) < 2)
 		return;
-	
+
 	timestamp = curtime;
-	
+
 	pthread_attr_t popup_thread_attr;
 	pthread_attr_init(&popup_thread_attr);
 	pthread_attr_setdetachstate(&popup_thread_attr, PTHREAD_CREATE_DETACHED);
-	
+
 	log_message(DEBUG, _("Show popup message \"%s\" with content \"%s\""), xconfig->popups[notify].file, command);
 
 	struct _popup_body *popup_body = (struct _popup_body*) malloc(sizeof (struct _popup_body));
@@ -131,7 +129,7 @@ void popup_show(int notify, char *command)
 		popup_body->header = strdup(xconfig->popups[notify].file);
 	if (command != NULL)
 		popup_body->content = strdup(command);
-	
+
 	pthread_t popup_thread;
 	pthread_create(&popup_thread, &popup_thread_attr, (void*) &popup_show_thread, (void*)popup_body);
 

--- a/xneur/plugins/statistic/statistic.c
+++ b/xneur/plugins/statistic/statistic.c
@@ -44,7 +44,7 @@ struct _xneur_statistic
 	time_t end_time;
 
 	int key_count;
-	
+
 	int change_incidental_caps;
 	int change_two_capital_letter;
 	int change_word_to_0;
@@ -85,7 +85,7 @@ struct _xneur_statistic
 int on_init(void)
 {
 	statistic.key_count = 0;
-	
+
 	statistic.change_incidental_caps = 0;
 	statistic.change_two_capital_letter = 0;
 	statistic.change_word_to_0 = 0;
@@ -121,7 +121,7 @@ int on_init(void)
 	statistic.action_rotate_layout = 0;
 	statistic.action_replace_abbreviation = 0;
 	statistic.action_autocompletion = 0;
-	
+
 	printf("[PLG] Plugin for keyboard statistic initialized\n");
 	return (0);
 }
@@ -129,7 +129,7 @@ int on_init(void)
 int on_xneur_start(void)
 {
 	statistic.start_time = time(NULL);
-	
+
 	printf("[PLG] Plugin for keyboard statistic receive xneur start\n");
 	return (0);
 }
@@ -149,30 +149,24 @@ int on_xneur_stop(void)
 		return 0;
 
 	statistic.end_time = time(NULL);
-	
-	char *start_time = malloc(256 * sizeof(char));
-	char *end_time = malloc(256 * sizeof(char));
-	
+
 	struct tm *loctime = localtime(&statistic.start_time);
 	if (loctime == NULL)
 	{
 		fclose(stream);
-		free(start_time);
-		free(end_time);
 		return 0;
 	}
-	strftime(start_time, 256, "%c", loctime);
+	char start_time[128];
+	strftime(start_time, sizeof(start_time)/sizeof(start_time[0]), "%c", loctime);
 
 	loctime = localtime(&statistic.end_time);
 	if (loctime == NULL)
 	{
 		fclose(stream);
-		free(start_time);
-		free(end_time);
 		return 0;
 	}
-	strftime(end_time, 256, "%c", loctime);
-	
+	char end_time[128];
+	strftime(end_time, sizeof(end_time)/sizeof(end_time[0]), "%c", loctime);
 
 	fprintf(stream, "XNeur statistic (from %s to %s)\n", start_time, end_time);
 	fprintf(stream, "Count:\n");
@@ -190,7 +184,7 @@ int on_xneur_stop(void)
 		fprintf(stream, "	Change two capital letter count = %d\n", statistic.change_two_capital_letter);
 	}
 	if (statistic.change_word_to_0 != 0)
-	{	
+	{
 		fprintf(stream, "	Change word to layout 0 count = %d\n", statistic.change_word_to_0);
 	}
 	if (statistic.change_word_to_1 != 0)
@@ -319,20 +313,18 @@ int on_xneur_stop(void)
 		fprintf(stream, "	Autocompletion count = %d\n", statistic.action_autocompletion);
 	}
 	fprintf(stream, "\n");
-	
+
 	printf("[PLG] Plugin for keyboard statistic receive xneur stop\n");
-	
+
 	fclose(stream);
-	free(start_time);
-	free(end_time);
-	
+
 	return (0);
 }
 
 int on_key_press(KeySym key, int modifier_mask)
 {
 	statistic.key_count++;
-	
+
 	printf("[PLG] Plugin for keyboard statistic receive KeyPress '%s' with mask %d\n", XKeysymToString(key), modifier_mask);
 	return (0);
 }
@@ -440,14 +432,14 @@ int on_hotkey_action(enum _hotkey_action ha)
 			break;
 		}
 	}*/
-	
+
 	return (0);
 }
 
 int on_change_action(enum _change_action ca)
 {
 	if (ca) {};
-	
+
 	/*switch (ca)
 	{
 		case CHANGE_INCIDENTAL_CAPS:
@@ -531,7 +523,7 @@ int on_change_action(enum _change_action ca)
 			break;
 		}
 	}*/
-	
+
 	return (0);
 }
 

--- a/xneur/src/newlang_creation.c
+++ b/xneur/src/newlang_creation.c
@@ -36,7 +36,63 @@
 #define NEW_LANG_TEXT	"new.text"
 
 extern struct _window *main_window;
+int need_skip(char ch) {
+	return isblank(ch) || iscntrl(ch) || isspace(ch) || ispunct(ch) || isdigit(ch);
+}
+void generate(struct _keymap *keymap, struct _list_char *proto2, struct _list_char *proto3, const char* text, int i, int group, int state) {
+	char buffer[256 + 1];
 
+	char *sym_i = keymap->keycode_to_symbol(keymap, i, group, state);
+	if (need_skip(sym_i[0])) {
+		free(sym_i);
+		return;
+	}
+	for (int j = 0; j < 100; j++)
+	{
+		char *sym_j = keymap->keycode_to_symbol(keymap, j, group, state);
+		if (need_skip(sym_j[0])) {
+			free(sym_j);
+			continue;
+		}
+
+		strcpy(buffer, sym_i);
+		strcat(buffer, sym_j);
+
+		if (proto2->exist(proto2, buffer, BY_PLAIN)) {
+			free(sym_j);
+			continue;
+		}
+
+		if (strstr(text, buffer) == NULL)
+		{
+			proto2->add(proto2, buffer);
+			free(sym_j);
+			continue;
+		}
+
+		for (int k = 0; k < 100; k++)
+		{
+			char *sym_k = keymap->keycode_to_symbol(keymap, k, group, state);
+			if (need_skip(sym_k[0])) {
+				free(sym_k);
+				continue;
+			}
+
+			sprintf(buffer, "%s%s%s", sym_i, sym_j, sym_k);
+			free(sym_k);
+
+			if (proto3->exist(proto3, buffer, BY_PLAIN))
+				continue;
+
+			if (strstr(text, buffer) != NULL)
+				continue;
+
+			proto3->add(proto3, buffer);
+		}
+		free(sym_j);
+	}
+	free(sym_i);
+}
 void generate_protos(void)
 {
 	printf("THIS OPTION FOR DEVELOPERS ONLY!\n");
@@ -67,95 +123,15 @@ void generate_protos(void)
 		exit(EXIT_FAILURE);
 	}
 
-	struct _list_char *proto  = list_char_init();//-V656
+	struct _list_char *proto2 = list_char_init();//-V656
 	struct _list_char *proto3 = list_char_init();//-V656
-
-	char syll[256 + 1];
 
 	for (int i = 0; i < 100; i++)
 	{
 		printf("%d\n", i);
 
-		char *sym_i = keymap->keycode_to_symbol(keymap, i, new_lang_group, 0);
-		if (isblank(sym_i[0]) || iscntrl(sym_i[0]) || isspace(sym_i[0]) || ispunct(sym_i[0]) || isdigit(sym_i[0]))
-			continue;
-		for (int j = 0; j < 100; j++)
-		{
-			char *sym_j = keymap->keycode_to_symbol(keymap, j, new_lang_group, 0);
-			if (isblank(sym_j[0]) || iscntrl(sym_j[0]) || isspace(sym_j[0]) || ispunct(sym_j[0]) || isdigit(sym_j[0]))
-				continue;
-
-			strcpy(syll, sym_i);
-			strcat(syll, sym_j);
-
-			if (proto->exist(proto, syll, BY_PLAIN))
-				continue;
-
-			if (strstr(text, syll) == NULL)
-			{
-				proto->add(proto, syll);
-				continue;
-			}
-
-			for (int k = 0; k < 100; k++)
-			{
-				char *sym_k = keymap->keycode_to_symbol(keymap, k, new_lang_group, 0);
-				if (isblank(sym_k[0]) || iscntrl(sym_k[0]) || isspace(sym_k[0]) || ispunct(sym_k[0]) || isdigit(sym_k[0]))
-					continue;
-
-				sprintf(syll, "%s%s%s", sym_i, sym_j, sym_k);
-
-				if (proto3->exist(proto3, syll, BY_PLAIN))
-					continue;
-
-				if (strstr(text, syll) != NULL)
-					continue;
-
-				proto3->add(proto3, syll);
-			}
-		}
-	}
-
-	for (int i = 0; i < 100; i++)
-	{
-		char *sym_i = keymap->keycode_to_symbol(keymap, i, new_lang_group, 1 << 7);
-		if (isblank(sym_i[0]) || iscntrl(sym_i[0]) || isspace(sym_i[0]) || ispunct(sym_i[0]) || isdigit(sym_i[0]))
-			continue;
-		for (int j = 0; j < 100; j++)
-		{
-			char *sym_j = keymap->keycode_to_symbol(keymap, j, new_lang_group, 1 << 7);
-			if (isblank(sym_j[0]) || iscntrl(sym_j[0]) || isspace(sym_j[0]) || ispunct(sym_j[0]) || isdigit(sym_j[0]))
-				continue;
-
-			strcpy(syll, sym_i);
-			strcat(syll, sym_j);
-
-			if (proto->exist(proto, syll, BY_PLAIN))
-				continue;
-
-			if (strstr(text, syll) == NULL)
-			{
-				proto->add(proto, syll);
-				continue;
-			}
-
-			for (int k = 0; k < 100; k++)
-			{
-				char *sym_k = keymap->keycode_to_symbol(keymap, k, new_lang_group, 1 << 7);
-				if (isblank(sym_k[0]) || iscntrl(sym_k[0]) || isspace(sym_k[0]) || ispunct(sym_k[0]) || isdigit(sym_k[0]))
-					continue;
-
-				sprintf(syll, "%s%s%s", sym_i, sym_j, sym_k);
-
-				if (proto3->exist(proto3, syll, BY_PLAIN))
-					continue;
-
-				if (strstr(text, syll) != NULL)
-					continue;
-
-				proto3->add(proto3, syll);
-			}
-		}
+		generate(keymap, proto2, proto3, text, i, new_lang_group, 0);
+		generate(keymap, proto2, proto3, text, i, new_lang_group, 1 << 7);
 	}
 
 	free(text);
@@ -165,12 +141,12 @@ void generate_protos(void)
 	if (stream == NULL)
 	{
 		free(proto_file_path);
-		proto->uninit(proto);
+		proto2->uninit(proto2);
 		proto3->uninit(proto3);
 		return;
 	}
-	proto->save(proto, stream);
-	printf("Short proto writed (%d) to %s\n", proto->data_count, proto_file_path);
+	proto2->save(proto2, stream);
+	printf("Short proto writed (%d) to %s\n", proto2->data_count, proto_file_path);
 	fclose(stream);
 	free(proto_file_path);
 
@@ -179,7 +155,7 @@ void generate_protos(void)
 	if (stream == NULL)
 	{
 		free(proto3_file_path);
-		proto->uninit(proto);
+		proto2->uninit(proto2);
 		proto3->uninit(proto3);
 		return;
 	}
@@ -188,7 +164,7 @@ void generate_protos(void)
 	fclose(stream);
 	free(proto3_file_path);
 
-	proto->uninit(proto);
+	proto2->uninit(proto2);
 	proto3->uninit(proto3);
 
 	printf("End of generation!\n");

--- a/xneur/src/newlang_creation.c
+++ b/xneur/src/newlang_creation.c
@@ -70,7 +70,7 @@ void generate_protos(void)
 	struct _list_char *proto  = list_char_init();//-V656
 	struct _list_char *proto3 = list_char_init();//-V656
 
-	char *syll = (char *) malloc((256 + 1) * sizeof(char));
+	char syll[256 + 1];
 
 	for (int i = 0; i < 100; i++)
 	{
@@ -164,7 +164,6 @@ void generate_protos(void)
 	FILE *stream = fopen(proto_file_path, "w");
 	if (stream == NULL)
 	{
-		free(syll);
 		free(proto_file_path);
 		proto->uninit(proto);
 		proto3->uninit(proto3);
@@ -179,7 +178,6 @@ void generate_protos(void)
 	stream = fopen(proto3_file_path, "w");
 	if (stream == NULL)
 	{
-		free(syll);
 		free(proto3_file_path);
 		proto->uninit(proto);
 		proto3->uninit(proto3);
@@ -192,8 +190,6 @@ void generate_protos(void)
 
 	proto->uninit(proto);
 	proto3->uninit(proto3);
-
-	free(syll);
 
 	printf("End of generation!\n");
 }


### PR DESCRIPTION
Исправлено несколько случаев некорректного использования функций освобождения памяти -- память выделялась функцией от одного API, а освобождалась функцией от другого API. На практике возможно, что проблемы никогда не возникало, т.к. вероятно все специализированные функции работы с памятью являются обертками для обычных `malloc/free`.

Затем, убрано динамическое выделение памяти, когда можно обойтись статическим выделением. Удалены ненужные проверки на `NULL` перед освобождением памяти.

Исправлено 2 проблемы: двойное освобождение памяти при работе с экранными уведомлениями (OSD) -- один раз в запускающем потоке, второй раз в рабочем; и утечки памяти в генераторе proto-файлов