### PR TITLE
Исправление 3-х предупреждей clang-tidy, связанных с проверкой по словарям

### DIFF
--- a/xneur/lib/ai/detection.h
+++ b/xneur/lib/ai/detection.h
@@ -25,8 +25,6 @@
 #include "buffer.h"
 #include "xneur.h"
 
-int check_lang(struct _xneur_handle *handle, struct _buffer *p, int cur_lang);
-
-int check_lang_with_similar_words(struct _xneur_handle *handle, struct _buffer *p, int cur_lang);
+int check_lang(struct _xneur_handle *handle, struct _buffer *p, int cur_lang, int check_similar_words);
 
 #endif /* _DETECTION_H_ */

--- a/xneur/lib/config/xnconfig_files.c
+++ b/xneur/lib/config/xnconfig_files.c
@@ -192,19 +192,16 @@ struct _list_char* load_list(const char *dir_name, const char *file_name, int so
 	struct _list_char *list = list_char_init();
 	char *file_path_name = get_file_path_name(dir_name, file_name);
 	char *content = get_file_content(file_path_name);
-	if (content == NULL)
-	{
-		free(file_path_name);
-		return list;
-	}
-
-	list->load(list, content);
-
-	free(content);
 	free(file_path_name);
 
-	if (sort_flag == TRUE)
-		list->sort(list);
+	if (content != NULL)
+	{
+		list->load(list, content);
+
+		if (sort_flag == TRUE)
+			list->sort(list);
+	}
+	free(content);
 
 	return list;
 }
@@ -213,16 +210,13 @@ int save_list(struct _list_char *list, const char *dir_name, const char *file_na
 {
 	char *file_path_name = get_home_file_path_name(dir_name, file_name);
 	FILE *stream = fopen(file_path_name, "w");
-	if (stream == NULL)
-	{
-		free(file_path_name);
-		return FALSE;
-	}
-
-	list->save(list, stream);
-
-	fclose(stream);
 	free(file_path_name);
 
-	return TRUE;
+	if (stream != NULL)
+	{
+		list->save(list, stream);
+		fclose(stream);
+		return TRUE;
+	}
+	return FALSE;
 }

--- a/xneur/lib/lib/xneur.h
+++ b/xneur/lib/lib/xneur.h
@@ -61,8 +61,8 @@ struct _xneur_handle
 #ifdef WITH_ASPELL
 	// global aspell dictionaries
 	AspellConfig *spell_config;
+	/// Array of dictionaries for each language
 	AspellSpeller **spell_checkers;
-	int *has_spell_checker;
 #endif
 
 #ifdef WITH_ENCHANT

--- a/xneur/lib/lib/xneur.h
+++ b/xneur/lib/lib/xneur.h
@@ -52,7 +52,7 @@ struct _xneur_language
 	struct _list_char *pattern;
 };
 
-// Main xneur structure 
+// Main xneur structure
 struct _xneur_handle
 {
 	struct _xneur_language *languages;
@@ -68,9 +68,9 @@ struct _xneur_handle
 #ifdef WITH_ENCHANT
 	// global enchant dictionaries
 	EnchantBroker *enchant_broker;
+	/// Array of dictionaries for each language
 	EnchantDict **enchant_dicts;
-	int *has_enchant_checker;
-#endif	
+#endif
 };
 
 // Initialyze structure (must be installed proto, proto3, dict and regexp)

--- a/xneur/lib/lib/xneurlib.c
+++ b/xneur/lib/lib/xneurlib.c
@@ -85,19 +85,32 @@ static void free_layout(char **names, int gc) {
 }*/
 
 #if  defined(WITH_ASPELL) || defined(WITH_ENCHANT)
-static char *layout_names[] =
+/// Returns name of dictionary for language
+static const char* spell_name(const struct _xneur_language* lang)
 {
-	"am","bg","by","cz","de","gr","ee","en","es","fr","ge","gb","kz","lt","lv",
-	"pl","ro","ru","ua","us","uz"
-};
+	static const char* LAYOUT_NAMES[] =
+	{
+		"am","bg","by","cz","de","gr","ee","en","es","fr","ge","gb","kz","lt","lv",
+		"pl","ro","ru","ua","us","uz"
+	};
 
-static char *spell_names[] =
-{
-	"hy","bg","be","cs","de","el","et","en","es","fr","ka","en","kk","lt","lv",
-	"pl","ro","ru","uk","en","uz"
-};
+	static const char* SPELL_NAMES[] =
+	{
+		"hy","bg","be","cs","de","el","et","en","es","fr","ka","en","kk","lt","lv",
+		"pl","ro","ru","uk","en","uz"
+	};
 
-static const int names_len = sizeof(layout_names) / sizeof(layout_names[0]);
+	static const size_t NAMES_LEN = sizeof(LAYOUT_NAMES) / sizeof(LAYOUT_NAMES[0]);
+
+	size_t i = 0;
+	for (; i < NAMES_LEN; ++i)
+	{
+		if (strcmp(LAYOUT_NAMES[i], lang->dir) == 0) {
+			break;
+		}
+	}
+	return i != NAMES_LEN ? SPELL_NAMES[i] : NULL;
+}
 #endif
 
 static long get_next_property_value (unsigned char **pointer, long unsigned *length, int size, char **string)
@@ -113,7 +126,7 @@ static long get_next_property_value (unsigned char **pointer, long unsigned *len
 
 struct _xneur_handle *xneur_handle_create (void)
 {
-	struct _xneur_handle *handle = (struct _xneur_handle *) malloc(sizeof(struct _xneur_handle));;
+	struct _xneur_handle *handle = (struct _xneur_handle *) malloc(sizeof(struct _xneur_handle));
 	if (handle == NULL)
 		return NULL;
 
@@ -305,16 +318,10 @@ struct _xneur_handle *xneur_handle_create (void)
 	{
 		const struct _xneur_language* l = &handle->languages[lang];
 		// initialize aspell checker for current language
-		int i = 0;
-		for (i = 0; i < names_len; i++)
+		const char* dict = spell_name(l);
+		if (dict != NULL)
 		{
-			if (strcmp(layout_names[i], l->dir) == 0)
-				break;
-
-		}
-		if (i != names_len)
-		{
-			aspell_config_replace(handle->spell_config, "lang", spell_names[i]);
+			aspell_config_replace(handle->spell_config, "lang", dict);
 			AspellCanHaveError *possible_err = new_aspell_speller(handle->spell_config);
 
 			int aspell_error = aspell_error_number(possible_err);
@@ -345,23 +352,18 @@ struct _xneur_handle *xneur_handle_create (void)
 	{
 		const struct _xneur_language* l = &handle->languages[lang];
 		// initialize enchant checker for current language
-		int j = 0;
-		for (j = 0; j < names_len; j++)
-		{
-			if (strcmp(layout_names[j], l->dir) == 0)
-				break;
-		}
-		if (j != names_len)
+		const char* dict = spell_name(l);
+		if (dict != NULL)
 		{
 			handle->enchant_dicts[lang] = NULL;
-			size_t len1 = strlen(spell_names[j]);
+			size_t len1 = strlen(dict);
 			size_t len2 = strlen(l->dir);
 			// +1 for "_" and +1 for trailing zero
 			char *dict_name = malloc(len1 + 1 + len2 + 1);
 			if (dict_name == NULL)
 				continue;
-			dict_name[0] = NULLSYM;
-			strncat(dict_name, spell_names[j], len1);
+			dict_name[0] = '\0';
+			strncat(dict_name, dict, len1);
 			strncat(dict_name, "_", 1);
 			strncat(dict_name, l->dir, len2);
 			dict_name[3] = toupper(dict_name[3]);
@@ -369,7 +371,7 @@ struct _xneur_handle *xneur_handle_create (void)
 			//printf("   [!] Try load dict %s\n", dict_name);
 			if (enchant_broker_dict_exists(handle->enchant_broker, dict_name) == FALSE)
 			{
-				dict_name[2] = NULLSYM;
+				dict_name[2] = '\0';
 				//printf("   [!] Try load dict %s\n", dict_name);
 				if (enchant_broker_dict_exists(handle->enchant_broker, dict_name) == FALSE)
 				{

--- a/xneur/lib/lib/xneurlib.c
+++ b/xneur/lib/lib/xneurlib.c
@@ -473,7 +473,7 @@ int xneur_get_layout (struct _xneur_handle *handle, char *word)
 
 	buffer->set_content(buffer, word);
 	int cur_lang = get_curr_keyboard_group();
-	int new_lang = check_lang(handle, buffer, cur_lang);
+	int new_lang = check_lang(handle, buffer, cur_lang, FALSE);
 
 	buffer->uninit(buffer);
 
@@ -495,7 +495,7 @@ char *xneur_get_word (struct _xneur_handle *handle, char *word)
 
 	buffer->set_content(buffer, word);
 	int cur_lang = get_curr_keyboard_group();
-	int new_lang = check_lang(handle, buffer, cur_lang);
+	int new_lang = check_lang(handle, buffer, cur_lang, FALSE);
 	if (new_lang == NO_LANGUAGE)
 		result = strdup(word);
 	else

--- a/xneur/lib/lib/xneurlib.c
+++ b/xneur/lib/lib/xneurlib.c
@@ -285,9 +285,8 @@ struct _xneur_handle *xneur_handle_create (void)
 
 #ifdef WITH_ASPELL
 	// init aspell spellers
-	handle->spell_checkers = (AspellSpeller **) malloc(handle->total_languages * sizeof(AspellSpeller*));
-	handle->has_spell_checker = (int *) malloc(handle->total_languages * sizeof(int));
 	handle->spell_config = new_aspell_config();
+	handle->spell_checkers = (AspellSpeller**) calloc(handle->total_languages, sizeof(AspellSpeller*));
 #endif
 
 #ifdef WITH_ENCHANT
@@ -329,19 +328,12 @@ struct _xneur_handle *xneur_handle_create (void)
 			{
 				//printf("   [!] Error initialize %s aspell dictionary\n", l->name);
 				delete_aspell_can_have_error(possible_err);
-				handle->has_spell_checker[lang] = 0;
 			}
 			else
 			{
 				//printf("   [!] Initialize %s aspell dictionary\n", l->name);
 				handle->spell_checkers[lang] = to_aspell_speller(possible_err);
-				handle->has_spell_checker[lang] = 1;
 			}
-		}
-		else
-		{
-			//printf("   [!] Now we don't support aspell dictionary for %s layout\n", l->dir);
-			handle->has_spell_checker[lang] = 0;
 		}
 	}
 #endif
@@ -396,7 +388,7 @@ struct _xneur_handle *xneur_handle_create (void)
 				l->proto->data_count == 0 &&
 				l->big_proto->data_count == 0
 #ifdef WITH_ASPELL
-				&& handle->has_spell_checker[lang] == 0
+				&& handle->spell_checkers[lang] == NULL
 #endif
 #ifdef WITH_ENCHANT
 				&& handle->enchant_dicts[lang] == NULL
@@ -415,7 +407,7 @@ void xneur_handle_destroy (struct _xneur_handle *handle)
 	for (int lang = 0; lang < handle->total_languages; lang++)
 	{
 #ifdef WITH_ASPELL
-		if (handle->has_spell_checker[lang])
+		if (handle->spell_checkers[lang])
 			delete_aspell_speller(handle->spell_checkers[lang]);
 #endif
 
@@ -440,7 +432,6 @@ void xneur_handle_destroy (struct _xneur_handle *handle)
 #ifdef WITH_ASPELL
 	delete_aspell_config(handle->spell_config);
 	free(handle->spell_checkers);
-	free(handle->has_spell_checker);
 #endif
 
 #ifdef WITH_ENCHANT

--- a/xneur/lib/main/buffer.c
+++ b/xneur/lib/main/buffer.c
@@ -308,14 +308,16 @@ static void buffer_clear(struct _buffer *p)
 
 	for (int i=0; i<p->handle->total_languages; i++)
 	{
-		char *tmp = realloc(p->i18n_content[i].content, sizeof(char));
+		struct _buffer_content *buf = &p->i18n_content[i];
+
+		char *tmp = realloc(buf->content, sizeof(char));
 		if (tmp != NULL)
-			p->i18n_content[i].content = tmp;
-		p->i18n_content[i].content[0] = NULLSYM;
-		tmp = realloc(p->i18n_content[i].content_unchanged, sizeof(char));
+			buf->content = tmp;
+		buf->content[0] = '\0';
+		tmp = realloc(buf->content_unchanged, sizeof(char));
 		if (tmp != NULL)
-			p->i18n_content[i].content_unchanged = tmp;
-		p->i18n_content[i].content_unchanged[0] = NULLSYM;
+			buf->content_unchanged = tmp;
+		buf->content_unchanged[0] = '\0';
 	}
 }
 
@@ -482,8 +484,9 @@ static void buffer_del_symbol(struct _buffer *p)
 
 	for (int i = 0; i < p->handle->total_languages; i++)
 	{
-		p->i18n_content[i].content[strlen(p->i18n_content[i].content) - p->i18n_content[i].symbol_len[p->cur_pos]] = NULLSYM;
-		p->i18n_content[i].content_unchanged[strlen(p->i18n_content[i].content_unchanged) - p->i18n_content[i].symbol_len_unchanged[p->cur_pos]] = NULLSYM;
+		struct _buffer_content *buf = &p->i18n_content[i];
+		buf->content          [strlen(buf->content          ) - buf->symbol_len          [p->cur_pos]] = '\0';
+		buf->content_unchanged[strlen(buf->content_unchanged) - buf->symbol_len_unchanged[p->cur_pos]] = '\0';
 	}
 }
 
@@ -657,19 +660,17 @@ static void buffer_uninit(struct _buffer *p)
 	free(p->keycode);
 	free(p->content);
 
-	if (p->i18n_content != NULL)
+	for (int i = 0; i < p->handle->total_languages; i++)
 	{
-		for (int i = 0; i < p->handle->total_languages; i++)
-		{
-			free(p->i18n_content[i].content);
-			free(p->i18n_content[i].symbol_len);
-			free(p->i18n_content[i].content_unchanged);
-			free(p->i18n_content[i].symbol_len_unchanged);
-		}
+		struct _buffer_content *buf = &p->i18n_content[i];
 
-		free(p->i18n_content);
+		free(buf->content);
+		free(buf->symbol_len);
+		free(buf->content_unchanged);
+		free(buf->symbol_len_unchanged);
 	}
 
+	free(p->i18n_content);
 	free(p);
 
 	log_message(DEBUG, _("String is freed"));
@@ -697,12 +698,14 @@ struct _buffer* buffer_init(struct _xneur_handle *handle, struct _keymap *keymap
 	p->i18n_content = (struct _buffer_content *) malloc((handle->total_languages) * sizeof(struct _buffer_content));
 	for (int i=0; i<p->handle->total_languages; i++)
 	{
-		p->i18n_content[i].content = malloc(sizeof(char));
-		p->i18n_content[i].content[0] = NULLSYM;
-		p->i18n_content[i].symbol_len = malloc(sizeof(int));
-		p->i18n_content[i].content_unchanged = malloc(sizeof(char));
-		p->i18n_content[i].content_unchanged[0] = NULLSYM;
-		p->i18n_content[i].symbol_len_unchanged = malloc(sizeof(int));
+		struct _buffer_content *buf = &p->i18n_content[i];
+
+		buf->content = malloc(sizeof(char));
+		buf->content[0] = '\0';
+		buf->symbol_len = malloc(sizeof(int));
+		buf->content_unchanged = malloc(sizeof(char));
+		buf->content_unchanged[0] = '\0';
+		buf->symbol_len_unchanged = malloc(sizeof(int));
 	}
 
 	// Functions mapping

--- a/xneur/lib/main/program.c
+++ b/xneur/lib/main/program.c
@@ -1430,9 +1430,7 @@ static int program_perform_action(struct _program *p, enum _hotkey_action action
 static int change(struct _program *p, int action, int check_similar_words)
 {
 	int cur_lang = get_curr_keyboard_group();
-	int new_lang = check_similar_words
-		? check_lang_with_similar_words(xconfig->handle, p->buffer, cur_lang)
-		: check_lang(xconfig->handle, p->buffer, cur_lang);
+	int new_lang = check_lang(xconfig->handle, p->buffer, cur_lang, check_similar_words);
 
 	if (new_lang == NO_LANGUAGE)
 	{

--- a/xneur/lib/main/program.c
+++ b/xneur/lib/main/program.c
@@ -433,7 +433,7 @@ static void program_process_input(struct _program *p)
 					log_message(DEBUG, _("      %s proto has %d records"), lang_name, xconfig->handle->languages[lang].proto->data_count);
 					log_message(DEBUG, _("      %s big proto has %d records"), lang_name, xconfig->handle->languages[lang].big_proto->data_count);
 			#ifdef WITH_ASPELL
-					if (xconfig->handle->has_spell_checker[lang])
+					if (xconfig->handle->spell_checkers[lang])
 					{
 						log_message(DEBUG, _("      %s aspell dictionary loaded"), lang_name);
 					}
@@ -2257,18 +2257,15 @@ static void program_check_misprint(struct _program *p)
 #endif
 
 #ifdef WITH_ASPELL
-	if (!xconfig->handle->has_spell_checker[lang])
+	AspellSpeller* dict = xconfig->handle->spell_checkers[lang];
+	size_t word_len = strlen(word + offset);
+	if (!dict || aspell_speller_check(dict, word + offset, word_len))
 	{
 		free(word);
 		return;
 	}
-	if (aspell_speller_check(xconfig->handle->spell_checkers[lang], word+offset, strlen(word+offset)))
-	{
-		free(word);
-		return;
-	}
-	const AspellWordList *suggestions = aspell_speller_suggest (xconfig->handle->spell_checkers[lang], (const char *) word+offset, strlen(word+offset));
-	if (! suggestions)
+	const AspellWordList *suggestions = aspell_speller_suggest(dict, (const char *) word + offset, word_len);
+	if (!suggestions)
 	{
 		free(word);
 		return;
@@ -3068,7 +3065,7 @@ static void program_add_word_to_pattern(struct _program *p, int new_lang)
 	}
 
 #ifdef WITH_ASPELL
-	if (xconfig->handle->has_spell_checker[new_lang])
+	if (xconfig->handle->spell_checkers[new_lang])
 	{
 		if (!aspell_speller_check(xconfig->handle->spell_checkers[new_lang], new_word+offset, strlen(new_word)))
 		{

--- a/xneur/lib/main/program.c
+++ b/xneur/lib/main/program.c
@@ -2217,28 +2217,16 @@ static void program_check_misprint(struct _program *p)
 #ifdef WITH_ENCHANT
 	size_t count = 0;
 
-	if (!xconfig->handle->has_enchant_checker[lang])
-	{
+	EnchantDict* dict = xconfig->handle->enchant_dicts[lang];
+	size_t word_len = strlen(word + offset);
+	if (!dict || word_len <= 0 || !enchant_dict_check(dict, word + offset, word_len)) {
 		free(word);
 		return;
 	}
 
-	if (strlen(word+offset) <= 0)
-	{
-		free(word);
-		return;
-	}
-
-	if (!enchant_dict_check(xconfig->handle->enchant_dicts[lang], word+offset, strlen(word+offset)))
-	{
-		free(word);
-		return;
-	}
-
-	char **suggs = enchant_dict_suggest (xconfig->handle->enchant_dicts[lang], word+offset, strlen(word+offset), &count);
+	char **suggs = enchant_dict_suggest(dict, word + offset, word_len, &count);
 	if (count > 0)
 	{
-
 		for (unsigned int i = 0; i < count; i++)
 		{
 			int tmp_levenshtein = levenshtein(word+offset, suggs[i]);
@@ -2265,7 +2253,7 @@ static void program_check_misprint(struct _program *p)
 		}
 	}
 
-	enchant_dict_free_string_list(xconfig->handle->enchant_dicts[lang], suggs);
+	enchant_dict_free_string_list(dict, suggs);
 #endif
 
 #ifdef WITH_ASPELL
@@ -3091,7 +3079,7 @@ static void program_add_word_to_pattern(struct _program *p, int new_lang)
 #endif
 
 #ifdef WITH_ENCHANT
-	if (xconfig->handle->has_enchant_checker[new_lang])
+	if (xconfig->handle->enchant_dicts[new_lang])
 	{
 		if (strlen(new_word+offset) <= 0)
 		{

--- a/xneur/lib/main/program.c
+++ b/xneur/lib/main/program.c
@@ -2064,7 +2064,7 @@ static void program_check_pattern(struct _program *p)
 		return;
 	}
 
-	log_message (DEBUG, _("Recognition word '%s' from text '%s' (layout %d), autocompletation..."), pattern_data->string, word, get_curr_keyboard_group());
+	log_message (DEBUG, _("Recognition word '%s' from text '%s' (layout %d), autocompletion..."), pattern_data->string, word, get_curr_keyboard_group());
 
 	struct _buffer *tmp_buffer = buffer_init(xconfig->handle, main_window->keymap);
 
@@ -2148,7 +2148,7 @@ static void program_rotate_pattern(struct _program *p)
 	if (p->last_pattern_id == list_alike->data_count)
 		p->last_pattern_id = 0;
 
-    log_message (DEBUG, _("Next autocompletion word '%s' from text '%s' (layout %d), rotate autocompletation..."), list_alike->data[p->last_pattern_id].string, word, get_curr_keyboard_group());
+	log_message (DEBUG, _("Next autocompletion word '%s' from text '%s' (layout %d), rotate autocompletion..."), list_alike->data[p->last_pattern_id].string, word, get_curr_keyboard_group());
 
 	struct _buffer *tmp_buffer = buffer_init(xconfig->handle, main_window->keymap);
 

--- a/xneur/po/be.po
+++ b/xneur/po/be.po
@@ -1254,14 +1254,14 @@ msgstr ""
 
 #: lib/main/program.c:2127
 #, c-format
-msgid "Recognition word '%s' from text '%s' (layout %d), autocompletation..."
+msgid "Recognition word '%s' from text '%s' (layout %d), autocompletion..."
 msgstr ""
 
 #: lib/main/program.c:2213
 #, c-format
 msgid ""
 "Next autocompletion word '%s' from text '%s' (layout %d), rotate "
-"autocompletation..."
+"autocompletion..."
 msgstr ""
 
 #: lib/main/program.c:2405

--- a/xneur/po/de.po
+++ b/xneur/po/de.po
@@ -1249,14 +1249,14 @@ msgstr ""
 
 #: lib/main/program.c:2127
 #, c-format
-msgid "Recognition word '%s' from text '%s' (layout %d), autocompletation..."
+msgid "Recognition word '%s' from text '%s' (layout %d), autocompletion..."
 msgstr ""
 
 #: lib/main/program.c:2213
 #, c-format
 msgid ""
 "Next autocompletion word '%s' from text '%s' (layout %d), rotate "
-"autocompletation..."
+"autocompletion..."
 msgstr ""
 
 #: lib/main/program.c:2405

--- a/xneur/po/ro.po
+++ b/xneur/po/ro.po
@@ -1249,14 +1249,14 @@ msgstr ""
 
 #: lib/main/program.c:2127
 #, c-format
-msgid "Recognition word '%s' from text '%s' (layout %d), autocompletation..."
+msgid "Recognition word '%s' from text '%s' (layout %d), autocompletion..."
 msgstr ""
 
 #: lib/main/program.c:2213
 #, c-format
 msgid ""
 "Next autocompletion word '%s' from text '%s' (layout %d), rotate "
-"autocompletation..."
+"autocompletion..."
 msgstr ""
 
 #: lib/main/program.c:2405

--- a/xneur/po/ru.po
+++ b/xneur/po/ru.po
@@ -1329,14 +1329,14 @@ msgstr "Обнаружена строчная буква после точки, 
 
 #: lib/main/program.c:2127
 #, c-format
-msgid "Recognition word '%s' from text '%s' (layout %d), autocompletation..."
+msgid "Recognition word '%s' from text '%s' (layout %d), autocompletion..."
 msgstr "Распознано слово '%s' из текста '%s' (раскладка %d), автодополнение..."
 
 #: lib/main/program.c:2213
 #, c-format
 msgid ""
 "Next autocompletion word '%s' from text '%s' (layout %d), rotate "
-"autocompletation..."
+"autocompletion..."
 msgstr ""
 "Следующий вариант автодополнения '%s' из текста '%s' (раскладка %d), "
 "изменение автодополнения..."

--- a/xneur/po/uk.po
+++ b/xneur/po/uk.po
@@ -1260,14 +1260,14 @@ msgstr ""
 
 #: lib/main/program.c:2127
 #, c-format
-msgid "Recognition word '%s' from text '%s' (layout %d), autocompletation..."
+msgid "Recognition word '%s' from text '%s' (layout %d), autocompletion..."
 msgstr ""
 
 #: lib/main/program.c:2213
 #, c-format
 msgid ""
 "Next autocompletion word '%s' from text '%s' (layout %d), rotate "
-"autocompletation..."
+"autocompletion..."
 msgstr ""
 
 #: lib/main/program.c:2405

--- a/xneur/po/xneur.pot
+++ b/xneur/po/xneur.pot
@@ -1247,14 +1247,14 @@ msgstr ""
 
 #: lib/main/program.c:2127
 #, c-format
-msgid "Recognition word '%s' from text '%s' (layout %d), autocompletation..."
+msgid "Recognition word '%s' from text '%s' (layout %d), autocompletion..."
 msgstr ""
 
 #: lib/main/program.c:2213
 #, c-format
 msgid ""
 "Next autocompletion word '%s' from text '%s' (layout %d), rotate "
-"autocompletation..."
+"autocompletion..."
 msgstr ""
 
 #: lib/main/program.c:2405

--- a/xneur/src/xneur.c
+++ b/xneur/src/xneur.c
@@ -136,7 +136,7 @@ static void xneur_load_config(void)
 		log_message(DEBUG, _("      %s proto has %d records"), lang_name, xconfig->handle->languages[lang].proto->data_count);
 		log_message(DEBUG, _("      %s big proto has %d records"), lang_name, xconfig->handle->languages[lang].big_proto->data_count);
 #ifdef WITH_ASPELL
-		if (xconfig->handle->has_spell_checker[lang])
+		if (xconfig->handle->spell_checkers[lang])
 		{
 			log_message(DEBUG, _("      %s aspell dictionary loaded"), lang_name);
 		}


### PR DESCRIPTION
На самом деле, эти предупреждения незначительные, так как описанная ситуация возникает, когда `malloc` возвращает `NULL` в определенном месте, в этом случае программа и так не будет работать, потому что на самом деле я практически уверен, что вариант нехватки памяти не обрабатывается корректно.

В процессе рефакторинга удалены ненужные массивы с флагами использования словарей, вместо них для того используется признак наличия валидного указателя на словарь.

Также исправлена небольшая опечатка в отладочном сообщении.