### PR TITLE
Рефакторинг подсистемы управления окном с фокусом ввода

### DIFF
--- a/xneur/lib/main/focus.c
+++ b/xneur/lib/main/focus.c
@@ -257,8 +257,7 @@ static void focus_update_grab_events(struct _focus *p, int grab)
 
 	if (grab_input)
 	{
-		if (xconfig->tracking_mouse)
-			grab_button(main_window->display, TRUE);
+		grab_button(main_window->display, xconfig->tracking_mouse);
 	}
 	else
 	{

--- a/xneur/lib/main/focus.c
+++ b/xneur/lib/main/focus.c
@@ -62,7 +62,7 @@ static int focus_get_focus_status(struct _focus *p, int *forced_mode, int *exclu
 	char *new_app_name = NULL;
 
 	// Clear masking on unfocused window
-	//p->update_grab_events(p, TRUE);
+	//focus_update_grab_events(p, TRUE || p->last_excluded);
 
 	Window new_window;
 	int show_message = TRUE;
@@ -253,7 +253,7 @@ static void grab_all_keys(Display* display, Window window, int use_x_input_api, 
 
 static void focus_update_grab_events(struct _focus *p, int not_grab)
 {
-	if (not_grab || p->last_excluded)
+	if (not_grab)
 	{
 		grab_button(main_window->display, FALSE);
 		grab_all_keys(main_window->display, p->owner_window, has_x_input_extension, FALSE);
@@ -268,7 +268,7 @@ static void focus_update_grab_events(struct _focus *p, int not_grab)
 
 static void focus_click_key(struct _focus *p, KeySym keysym)
 {
-	focus_update_grab_events(p, TRUE);
+	focus_update_grab_events(p, TRUE || p->last_excluded);
 
 	KeyCode keycode = XKeysymToKeycode(main_window->display, keysym);
 
@@ -276,7 +276,7 @@ static void focus_click_key(struct _focus *p, KeySym keysym)
 	XTestFakeKeyEvent(main_window->display, keycode ,FALSE, 0); // key release event
 	XFlush(main_window->display);
 
-	focus_update_grab_events(p, FALSE);
+	focus_update_grab_events(p, FALSE || p->last_excluded);
 }
 
 static void focus_uninit(struct _focus *p)

--- a/xneur/lib/main/focus.c
+++ b/xneur/lib/main/focus.c
@@ -62,7 +62,7 @@ static int focus_get_focus_status(struct _focus *p, int *forced_mode, int *exclu
 	char *new_app_name = NULL;
 
 	// Clear masking on unfocused window
-	//focus_update_grab_events(p, TRUE || p->last_excluded);
+	//focus_update_grab_events(p, TRUE);
 
 	Window new_window;
 	int show_message = TRUE;
@@ -268,7 +268,7 @@ static void focus_update_grab_events(struct _focus *p, int not_grab)
 
 static void focus_click_key(struct _focus *p, KeySym keysym)
 {
-	focus_update_grab_events(p, TRUE || p->last_excluded);
+	focus_update_grab_events(p, TRUE);
 
 	KeyCode keycode = XKeysymToKeycode(main_window->display, keysym);
 
@@ -276,7 +276,7 @@ static void focus_click_key(struct _focus *p, KeySym keysym)
 	XTestFakeKeyEvent(main_window->display, keycode ,FALSE, 0); // key release event
 	XFlush(main_window->display);
 
-	focus_update_grab_events(p, FALSE || p->last_excluded);
+	focus_update_grab_events(p, p->last_excluded);
 }
 
 static void focus_uninit(struct _focus *p)

--- a/xneur/lib/main/focus.c
+++ b/xneur/lib/main/focus.c
@@ -265,8 +265,6 @@ static void grab_all_keys(Display* display, Window window, int use_x_input_api, 
 
 static void focus_update_grab_events(struct _focus *p, int mode)
 {
-	char *owner_window_name = get_wm_class_name(p->owner_window);
-
 	if ((mode == LISTEN_DONTGRAB_INPUT) || (p->last_focus == FOCUS_EXCLUDED))
 	{
 		grab_button(main_window->display, FALSE);
@@ -278,39 +276,6 @@ static void focus_update_grab_events(struct _focus *p, int mode)
 			grab_button(main_window->display, TRUE);
 		grab_all_keys(main_window->display, p->owner_window, has_x_input_extension, TRUE);
 	}
-
-	/*
-	if (mode == LISTEN_DONTGRAB_INPUT)
-	{
-		log_message (DEBUG, _("Interception of events in the window (ID %d) with name '%s' OFF"), p->owner_window, owner_window_name);
-
-		// Event unmasking
-		grab_button(p->owner_window, FALSE);
-		grab_all_keys(p->owner_window, FALSE);
-	}
-	else
-	{
-		log_message (DEBUG, _("Interception of events in the window (ID %d) with name '%s' ON"), p->owner_window, owner_window_name);
-
-		// Event masking
-		// Grabbing key and button
-		if (p->last_focus != FOCUS_EXCLUDED)
-		{
-			if (xconfig->tracking_mouse)
-			  grab_button(p->parent_window, TRUE);
-			grab_all_keys(p->owner_window, TRUE);
-		}
-		else
-		{
-			grab_button(p->owner_window, FALSE);
-			grab_all_keys(p->owner_window, FALSE);
-		}
-	}
-	*/
-
-	p->last_parent_window = p->parent_window;
-
-	free(owner_window_name);
 }
 
 static void focus_uninit(struct _focus *p)

--- a/xneur/lib/main/focus.c
+++ b/xneur/lib/main/focus.c
@@ -18,6 +18,7 @@
  */
 
 #include <X11/XKBlib.h>
+#include <X11/extensions/XInput2.h>
 
 #include <stdlib.h>
 #include <string.h>
@@ -213,20 +214,69 @@ static int focus_get_focus_status(struct _focus *p, int *forced_mode, int *focus
 	return focus;
 }
 
+static void grab_button(Display* display, int is_grab)
+{
+	XIEventMask mask;
+	mask.deviceid = XIAllMasterDevices;
+	mask.mask_len = XIMaskLen(XI_RawButtonPress);
+	mask.mask = (void *)calloc(mask.mask_len, sizeof(char));
+	XISetMask(mask.mask, is_grab ? XI_RawButtonPress : 0);
+	XISelectEvents(display, DefaultRootWindow(display), &mask, 1);
+	free(mask.mask);
+}
+
+static void grab_all_keys(Display* display, Window window, int use_x_input_api, int is_grab)
+{
+	if (is_grab)
+	{
+		// Grab all keys...
+		if (use_x_input_api) {
+			XIEventMask mask;
+			mask.deviceid = XIAllDevices;
+			mask.mask_len = XIMaskLen(XI_KeyPress)
+			              + XIMaskLen(XI_KeyRelease);
+			mask.mask = (void *)calloc(mask.mask_len, sizeof(char));
+			XISetMask(mask.mask, XI_KeyPress);
+			XISetMask(mask.mask, XI_KeyRelease);
+			XISelectEvents(display, DefaultRootWindow(display), &mask, 1);
+			free(mask.mask);
+		} else {
+			XGrabKey(display, AnyKey, AnyModifier, window, FALSE, GrabModeAsync, GrabModeAsync);
+		}
+	}
+	else
+	{
+		if (use_x_input_api) {
+			XIEventMask mask;
+			mask.deviceid = XIAllMasterDevices;
+			mask.mask_len = XIMaskLen(XI_KeyPress);
+			mask.mask = (void *)calloc(mask.mask_len, sizeof(char));
+			XISetMask(mask.mask, 0);
+			XISelectEvents(display, DefaultRootWindow(display), &mask, 1);
+			free(mask.mask);
+		} else {
+			// Ungrab all keys in app window...
+			XUngrabKey(display, AnyKey, AnyModifier, window);
+		}
+	}
+
+	XSelectInput(display, window, FOCUS_CHANGE_MASK);
+}
+
 static void focus_update_grab_events(struct _focus *p, int mode)
 {
 	char *owner_window_name = get_wm_class_name(p->owner_window);
 
 	if ((mode == LISTEN_DONTGRAB_INPUT) || (p->last_focus == FOCUS_EXCLUDED))
 	{
-		grab_button(FALSE);
-		grab_all_keys(p->owner_window, FALSE);
+		grab_button(main_window->display, FALSE);
+		grab_all_keys(main_window->display, p->owner_window, has_x_input_extension, FALSE);
 	}
 	else
 	{
 		if (xconfig->tracking_mouse)
-			grab_button(TRUE);
-		grab_all_keys(p->owner_window, TRUE);
+			grab_button(main_window->display, TRUE);
+		grab_all_keys(main_window->display, p->owner_window, has_x_input_extension, TRUE);
 	}
 
 	/*

--- a/xneur/lib/main/focus.c
+++ b/xneur/lib/main/focus.c
@@ -53,7 +53,7 @@ static int focus_is_focus_changed(struct _focus *p)
 	return new_window != p->owner_window;
 }
 
-static int get_focus(struct _focus *p, int *forced_mode, int *excluded, int *autocompletion_mode)
+static int focus_get_focus_status(struct _focus *p, int *forced_mode, int *excluded, int *autocompletion_mode)
 {
 	*forced_mode	= FORCE_MODE_NORMAL;
 	*excluded	= FALSE;
@@ -200,15 +200,6 @@ static int get_focus(struct _focus *p, int *forced_mode, int *excluded, int *aut
 
 	free(new_app_name);
 	return TRUE;
-}
-
-static int focus_get_focus_status(struct _focus *p, int *forced_mode, int *excluded, int *autocompletion_mode)
-{
-	int focus = get_focus(p, forced_mode, excluded, autocompletion_mode);
-
-	p->last_excluded = xconfig->tracking_input ? *excluded : TRUE;
-
-	return focus;
 }
 
 static void grab_button(Display* display, int is_grab)

--- a/xneur/lib/main/focus.c
+++ b/xneur/lib/main/focus.c
@@ -253,7 +253,9 @@ static void grab_all_keys(Display* display, Window window, int use_x_input_api, 
 
 static void focus_update_grab_events(struct _focus *p, int grab)
 {
-	if (grab)
+	int grab_input = xconfig->tracking_input && grab;
+
+	if (grab_input)
 	{
 		if (xconfig->tracking_mouse)
 			grab_button(main_window->display, TRUE);
@@ -262,7 +264,7 @@ static void focus_update_grab_events(struct _focus *p, int grab)
 	{
 		grab_button(main_window->display, FALSE);
 	}
-	grab_all_keys(main_window->display, p->owner_window, has_x_input_extension, grab);
+	grab_all_keys(main_window->display, p->owner_window, has_x_input_extension, grab_input);
 }
 
 static void focus_click_key(struct _focus *p, int excluded, KeySym keysym)
@@ -275,7 +277,7 @@ static void focus_click_key(struct _focus *p, int excluded, KeySym keysym)
 	XTestFakeKeyEvent(main_window->display, keycode ,FALSE, 0); // key release event
 	XFlush(main_window->display);
 
-	focus_update_grab_events(p, xconfig->tracking_input && !excluded);
+	focus_update_grab_events(p, !excluded);
 }
 
 static void focus_uninit(struct _focus *p)

--- a/xneur/lib/main/focus.c
+++ b/xneur/lib/main/focus.c
@@ -63,7 +63,7 @@ static int get_focus(struct _focus *p, int *forced_mode, int *focus_status, int 
 	char *new_app_name = NULL;
 
 	// Clear masking on unfocused window
-	//p->update_grab_events(p, LISTEN_DONTGRAB_INPUT);
+	//p->update_grab_events(p, FALSE);
 
 	Window new_window;
 	int show_message = TRUE;
@@ -261,9 +261,9 @@ static void grab_all_keys(Display* display, Window window, int use_x_input_api, 
 	XSelectInput(display, window, FOCUS_CHANGE_MASK);
 }
 
-static void focus_update_grab_events(struct _focus *p, int mode)
+static void focus_update_grab_events(struct _focus *p, int grab)
 {
-	if ((mode == LISTEN_DONTGRAB_INPUT) || (p->last_focus == FOCUS_EXCLUDED))
+	if (!grab || (p->last_focus == FOCUS_EXCLUDED))
 	{
 		grab_button(main_window->display, FALSE);
 		grab_all_keys(main_window->display, p->owner_window, has_x_input_extension, FALSE);

--- a/xneur/lib/main/focus.c
+++ b/xneur/lib/main/focus.c
@@ -275,6 +275,19 @@ static void focus_update_grab_events(struct _focus *p, int grab)
 	}
 }
 
+static void focus_click_key(struct _focus *p, KeySym keysym)
+{
+	focus_update_grab_events(p, FALSE);
+
+	KeyCode keycode = XKeysymToKeycode(main_window->display, keysym);
+
+	XTestFakeKeyEvent(main_window->display, keycode, TRUE,  0); // key press event
+	XTestFakeKeyEvent(main_window->display, keycode ,FALSE, 0); // key release event
+	XFlush(main_window->display);
+
+	focus_update_grab_events(p, TRUE);
+}
+
 static void focus_uninit(struct _focus *p)
 {
 	free(p);
@@ -291,6 +304,7 @@ struct _focus* focus_init(void)
 	p->get_focus_status	= focus_get_focus_status;
 	p->is_focus_changed = focus_is_focus_changed;
 	p->update_grab_events	= focus_update_grab_events;
+	p->click_key	= focus_click_key;
 	p->uninit		= focus_uninit;
 
 	return p;

--- a/xneur/lib/main/focus.c
+++ b/xneur/lib/main/focus.c
@@ -40,7 +40,7 @@ extern struct _xneur_config *xconfig;
 extern struct _window *main_window;
 
 const char *verbose_forced_mode[]	= {"Default", "Manual", "Automatic"};
-const char *verbose_focus_status[]	= {"Processed", "Changed Focus", "Unchanged Focus", "Excluded"};
+const char *verbose_focus_status[]	= {"Processed", "Excluded"};
 
 
 // Private
@@ -57,7 +57,7 @@ int focus_get_focused_window(struct _focus *p)
 static int get_focus(struct _focus *p, int *forced_mode, int *focus_status, int *autocompletion_mode)
 {
 	*forced_mode	= FORCE_MODE_NORMAL;
-	*focus_status	= FOCUS_NONE;
+	*focus_status	= FOCUS_PROCESSED;
 	*autocompletion_mode	= AUTOCOMPLETION_INCLUDED;
 
 	char *new_app_name = NULL;
@@ -156,7 +156,7 @@ static int get_focus(struct _focus *p, int *forced_mode, int *focus_status, int 
 			    (width_return == root_width_return) && (height_return == root_height_return))
 				*forced_mode = FORCE_MODE_MANUAL;
 		}
-		return FOCUS_UNCHANGED;
+		return FALSE;
 	}
 
 	log_message(DEBUG, _("Focused window %d"), new_window);
@@ -200,16 +200,14 @@ static int get_focus(struct _focus *p, int *forced_mode, int *focus_status, int 
 	log_message(DEBUG, _("Process new window (ID %d) with name '%s' (status %s, mode %s)"), new_window, new_app_name, _(verbose_focus_status[*focus_status]), _(verbose_forced_mode[*forced_mode]));
 
 	free(new_app_name);
-	return FOCUS_CHANGED;
+	return TRUE;
 }
 
 static int focus_get_focus_status(struct _focus *p, int *forced_mode, int *focus_status, int *autocompletion_mode)
 {
 	int focus = get_focus(p, forced_mode, focus_status, autocompletion_mode);
 
-	p->last_focus = *focus_status;
-	if (!xconfig->tracking_input)
-		p->last_focus = FOCUS_EXCLUDED;
+	p->last_focus = xconfig->tracking_input ? *focus_status : FOCUS_EXCLUDED;
 
 	return focus;
 }

--- a/xneur/lib/main/focus.c
+++ b/xneur/lib/main/focus.c
@@ -62,7 +62,7 @@ static int focus_get_focus_status(struct _focus *p, int *forced_mode, int *exclu
 	char *new_app_name = NULL;
 
 	// Clear masking on unfocused window
-	//focus_update_grab_events(p, TRUE);
+	//focus_update_grab_events(p, FALSE);
 
 	Window new_window;
 	int show_message = TRUE;
@@ -251,24 +251,24 @@ static void grab_all_keys(Display* display, Window window, int use_x_input_api, 
 	XSelectInput(display, window, FOCUS_CHANGE_MASK);
 }
 
-static void focus_update_grab_events(struct _focus *p, int not_grab)
+static void focus_update_grab_events(struct _focus *p, int grab)
 {
-	if (not_grab)
-	{
-		grab_button(main_window->display, FALSE);
-		grab_all_keys(main_window->display, p->owner_window, has_x_input_extension, FALSE);
-	}
-	else
+	if (grab)
 	{
 		if (xconfig->tracking_mouse)
 			grab_button(main_window->display, TRUE);
 		grab_all_keys(main_window->display, p->owner_window, has_x_input_extension, TRUE);
 	}
+	else
+	{
+		grab_button(main_window->display, FALSE);
+		grab_all_keys(main_window->display, p->owner_window, has_x_input_extension, FALSE);
+	}
 }
 
 static void focus_click_key(struct _focus *p, int excluded, KeySym keysym)
 {
-	focus_update_grab_events(p, TRUE);
+	focus_update_grab_events(p, FALSE);
 
 	KeyCode keycode = XKeysymToKeycode(main_window->display, keysym);
 
@@ -276,7 +276,7 @@ static void focus_click_key(struct _focus *p, int excluded, KeySym keysym)
 	XTestFakeKeyEvent(main_window->display, keycode ,FALSE, 0); // key release event
 	XFlush(main_window->display);
 
-	focus_update_grab_events(p, excluded);
+	focus_update_grab_events(p, !excluded);
 }
 
 static void focus_uninit(struct _focus *p)

--- a/xneur/lib/main/focus.c
+++ b/xneur/lib/main/focus.c
@@ -276,7 +276,7 @@ static void focus_click_key(struct _focus *p, int excluded, KeySym keysym)
 	XTestFakeKeyEvent(main_window->display, keycode ,FALSE, 0); // key release event
 	XFlush(main_window->display);
 
-	focus_update_grab_events(p, !excluded);
+	focus_update_grab_events(p, !(!xconfig->tracking_input || excluded));
 }
 
 static void focus_uninit(struct _focus *p)

--- a/xneur/lib/main/focus.c
+++ b/xneur/lib/main/focus.c
@@ -44,14 +44,13 @@ const char *verbose_focus_status[]	= {"Processed", "Excluded"};
 
 
 // Private
-int focus_get_focused_window(struct _focus *p)
+static int focus_is_focus_changed(struct _focus *p)
 {
-	if (p) {};
 	Window new_window;
 	int revert_to;
 	XGetInputFocus(main_window->display, &new_window, &revert_to);
 
-	return new_window;
+	return new_window != p->owner_window;
 }
 
 static int get_focus(struct _focus *p, int *forced_mode, int *excluded, int *autocompletion_mode)
@@ -290,7 +289,7 @@ struct _focus* focus_init(void)
 
 	// Functions mapping
 	p->get_focus_status	= focus_get_focus_status;
-	p->get_focused_window = focus_get_focused_window;
+	p->is_focus_changed = focus_is_focus_changed;
 	p->update_grab_events	= focus_update_grab_events;
 	p->uninit		= focus_uninit;
 

--- a/xneur/lib/main/focus.c
+++ b/xneur/lib/main/focus.c
@@ -62,7 +62,7 @@ static int focus_get_focus_status(struct _focus *p, int *forced_mode, int *exclu
 	char *new_app_name = NULL;
 
 	// Clear masking on unfocused window
-	//p->update_grab_events(p, FALSE);
+	//p->update_grab_events(p, TRUE);
 
 	Window new_window;
 	int show_message = TRUE;
@@ -251,9 +251,9 @@ static void grab_all_keys(Display* display, Window window, int use_x_input_api, 
 	XSelectInput(display, window, FOCUS_CHANGE_MASK);
 }
 
-static void focus_update_grab_events(struct _focus *p, int grab)
+static void focus_update_grab_events(struct _focus *p, int not_grab)
 {
-	if (!grab || p->last_excluded)
+	if (not_grab || p->last_excluded)
 	{
 		grab_button(main_window->display, FALSE);
 		grab_all_keys(main_window->display, p->owner_window, has_x_input_extension, FALSE);
@@ -268,7 +268,7 @@ static void focus_update_grab_events(struct _focus *p, int grab)
 
 static void focus_click_key(struct _focus *p, KeySym keysym)
 {
-	focus_update_grab_events(p, FALSE);
+	focus_update_grab_events(p, TRUE);
 
 	KeyCode keycode = XKeysymToKeycode(main_window->display, keysym);
 
@@ -276,7 +276,7 @@ static void focus_click_key(struct _focus *p, KeySym keysym)
 	XTestFakeKeyEvent(main_window->display, keycode ,FALSE, 0); // key release event
 	XFlush(main_window->display);
 
-	focus_update_grab_events(p, TRUE);
+	focus_update_grab_events(p, FALSE);
 }
 
 static void focus_uninit(struct _focus *p)

--- a/xneur/lib/main/focus.c
+++ b/xneur/lib/main/focus.c
@@ -257,13 +257,12 @@ static void focus_update_grab_events(struct _focus *p, int grab)
 	{
 		if (xconfig->tracking_mouse)
 			grab_button(main_window->display, TRUE);
-		grab_all_keys(main_window->display, p->owner_window, has_x_input_extension, TRUE);
 	}
 	else
 	{
 		grab_button(main_window->display, FALSE);
-		grab_all_keys(main_window->display, p->owner_window, has_x_input_extension, FALSE);
 	}
+	grab_all_keys(main_window->display, p->owner_window, has_x_input_extension, grab);
 }
 
 static void focus_click_key(struct _focus *p, int excluded, KeySym keysym)
@@ -276,7 +275,7 @@ static void focus_click_key(struct _focus *p, int excluded, KeySym keysym)
 	XTestFakeKeyEvent(main_window->display, keycode ,FALSE, 0); // key release event
 	XFlush(main_window->display);
 
-	focus_update_grab_events(p, !(!xconfig->tracking_input || excluded));
+	focus_update_grab_events(p, xconfig->tracking_input && !excluded);
 }
 
 static void focus_uninit(struct _focus *p)

--- a/xneur/lib/main/focus.c
+++ b/xneur/lib/main/focus.c
@@ -254,15 +254,9 @@ static void grab_all_keys(Display* display, Window window, int use_x_input_api, 
 static void focus_update_grab_events(struct _focus *p, int grab)
 {
 	int grab_input = xconfig->tracking_input && grab;
+	int grab_mouse = xconfig->tracking_mouse && grab_input;
 
-	if (grab_input)
-	{
-		grab_button(main_window->display, xconfig->tracking_mouse);
-	}
-	else
-	{
-		grab_button(main_window->display, FALSE);
-	}
+	grab_button(main_window->display, grab_mouse);
 	grab_all_keys(main_window->display, p->owner_window, has_x_input_extension, grab_input);
 }
 
@@ -276,7 +270,10 @@ static void focus_click_key(struct _focus *p, int excluded, KeySym keysym)
 	XTestFakeKeyEvent(main_window->display, keycode ,FALSE, 0); // key release event
 	XFlush(main_window->display);
 
-	focus_update_grab_events(p, !excluded);
+	// Enable events if they are not disabled for application
+	if (!excluded) {
+		focus_update_grab_events(p, TRUE);
+	}
 }
 
 static void focus_uninit(struct _focus *p)

--- a/xneur/lib/main/focus.c
+++ b/xneur/lib/main/focus.c
@@ -266,7 +266,7 @@ static void focus_update_grab_events(struct _focus *p, int not_grab)
 	}
 }
 
-static void focus_click_key(struct _focus *p, KeySym keysym)
+static void focus_click_key(struct _focus *p, int excluded, KeySym keysym)
 {
 	focus_update_grab_events(p, TRUE);
 
@@ -276,7 +276,7 @@ static void focus_click_key(struct _focus *p, KeySym keysym)
 	XTestFakeKeyEvent(main_window->display, keycode ,FALSE, 0); // key release event
 	XFlush(main_window->display);
 
-	focus_update_grab_events(p, p->last_excluded);
+	focus_update_grab_events(p, excluded);
 }
 
 static void focus_uninit(struct _focus *p)

--- a/xneur/lib/main/focus.h
+++ b/xneur/lib/main/focus.h
@@ -25,10 +25,6 @@
 #define FOCUS_PROCESSED		0
 #define FOCUS_EXCLUDED		1
 
-#define LISTEN_FLUSH		0
-#define LISTEN_GRAB_INPUT	1
-#define LISTEN_DONTGRAB_INPUT	2
-
 #define FORCE_MODE_NORMAL	0
 #define FORCE_MODE_MANUAL	1
 #define FORCE_MODE_AUTO		2
@@ -44,7 +40,7 @@ struct _focus
 
 	int  (*get_focus_status) (struct _focus *p, int *forced_mode, int *focus_status, int *autocompletion_mode);
 	int  (*get_focused_window) (struct _focus *p);
-	void (*update_grab_events) (struct _focus *p, int mode);
+	void (*update_grab_events) (struct _focus *p, int grab);
 	void (*uninit) (struct _focus *p);
 };
 

--- a/xneur/lib/main/focus.h
+++ b/xneur/lib/main/focus.h
@@ -38,6 +38,7 @@ struct _focus
 	int  (*get_focus_status) (struct _focus *p, int *forced_mode, int *excluded, int *autocompletion_mode);
 	int  (*is_focus_changed) (struct _focus *p);
 	void (*update_grab_events) (struct _focus *p, int grab);
+	void (*click_key) (struct _focus *p, KeySym keysym);
 	void (*uninit) (struct _focus *p);
 };
 

--- a/xneur/lib/main/focus.h
+++ b/xneur/lib/main/focus.h
@@ -37,7 +37,7 @@ struct _focus
 
 	int  (*get_focus_status) (struct _focus *p, int *forced_mode, int *excluded, int *autocompletion_mode);
 	int  (*is_focus_changed) (struct _focus *p);
-	void (*update_grab_events) (struct _focus *p, int not_grab);
+	void (*update_grab_events) (struct _focus *p, int grab);
 	void (*click_key) (struct _focus *p, int excluded, KeySym keysym);
 	void (*uninit) (struct _focus *p);
 };

--- a/xneur/lib/main/focus.h
+++ b/xneur/lib/main/focus.h
@@ -22,10 +22,8 @@
 
 #include <X11/XKBlib.h>
 
-#define FOCUS_NONE		0
-#define FOCUS_CHANGED		1
-#define FOCUS_UNCHANGED		2
-#define FOCUS_EXCLUDED		3
+#define FOCUS_PROCESSED		0
+#define FOCUS_EXCLUDED		1
 
 #define LISTEN_FLUSH		0
 #define LISTEN_GRAB_INPUT	1

--- a/xneur/lib/main/focus.h
+++ b/xneur/lib/main/focus.h
@@ -22,9 +22,6 @@
 
 #include <X11/XKBlib.h>
 
-#define FOCUS_PROCESSED		0
-#define FOCUS_EXCLUDED		1
-
 #define FORCE_MODE_NORMAL	0
 #define FORCE_MODE_MANUAL	1
 #define FORCE_MODE_AUTO		2
@@ -36,9 +33,9 @@ struct _focus
 {
 	Window owner_window;		// Input focus window
 	Window parent_window;		// Parent widget in window
-	int last_focus;			// Last focus status
+	int last_excluded;			// Last focus status
 
-	int  (*get_focus_status) (struct _focus *p, int *forced_mode, int *focus_status, int *autocompletion_mode);
+	int  (*get_focus_status) (struct _focus *p, int *forced_mode, int *excluded, int *autocompletion_mode);
 	int  (*get_focused_window) (struct _focus *p);
 	void (*update_grab_events) (struct _focus *p, int grab);
 	void (*uninit) (struct _focus *p);

--- a/xneur/lib/main/focus.h
+++ b/xneur/lib/main/focus.h
@@ -38,7 +38,7 @@ struct _focus
 	int  (*get_focus_status) (struct _focus *p, int *forced_mode, int *excluded, int *autocompletion_mode);
 	int  (*is_focus_changed) (struct _focus *p);
 	void (*update_grab_events) (struct _focus *p, int not_grab);
-	void (*click_key) (struct _focus *p, KeySym keysym);
+	void (*click_key) (struct _focus *p, int excluded, KeySym keysym);
 	void (*uninit) (struct _focus *p);
 };
 

--- a/xneur/lib/main/focus.h
+++ b/xneur/lib/main/focus.h
@@ -37,7 +37,7 @@ struct _focus
 
 	int  (*get_focus_status) (struct _focus *p, int *forced_mode, int *excluded, int *autocompletion_mode);
 	int  (*is_focus_changed) (struct _focus *p);
-	void (*update_grab_events) (struct _focus *p, int grab);
+	void (*update_grab_events) (struct _focus *p, int not_grab);
 	void (*click_key) (struct _focus *p, KeySym keysym);
 	void (*uninit) (struct _focus *p);
 };

--- a/xneur/lib/main/focus.h
+++ b/xneur/lib/main/focus.h
@@ -42,7 +42,6 @@ struct _focus
 {
 	Window owner_window;		// Input focus window
 	Window parent_window;		// Parent widget in window
-	Window last_parent_window;	// Last grab parent window
 	int last_focus;			// Last focus status
 
 	int  (*get_focus_status) (struct _focus *p, int *forced_mode, int *focus_status, int *autocompletion_mode);

--- a/xneur/lib/main/focus.h
+++ b/xneur/lib/main/focus.h
@@ -33,7 +33,6 @@ struct _focus
 {
 	Window owner_window;		// Input focus window
 	Window parent_window;		// Parent widget in window
-	int last_excluded;			// Last focus status
 
 	int  (*get_focus_status) (struct _focus *p, int *forced_mode, int *excluded, int *autocompletion_mode);
 	int  (*is_focus_changed) (struct _focus *p);

--- a/xneur/lib/main/focus.h
+++ b/xneur/lib/main/focus.h
@@ -36,7 +36,7 @@ struct _focus
 	int last_excluded;			// Last focus status
 
 	int  (*get_focus_status) (struct _focus *p, int *forced_mode, int *excluded, int *autocompletion_mode);
-	int  (*get_focused_window) (struct _focus *p);
+	int  (*is_focus_changed) (struct _focus *p);
 	void (*update_grab_events) (struct _focus *p, int grab);
 	void (*uninit) (struct _focus *p);
 };

--- a/xneur/lib/main/program.c
+++ b/xneur/lib/main/program.c
@@ -337,7 +337,7 @@ static void program_update(struct _program *p)
 		return;
 
 	p->event->set_owner_window(p->event, p->focus->owner_window);
-	p->focus->update_grab_events(p->focus, !p->app_excluded);
+	p->focus->update_grab_events(p->focus, p->app_excluded);
 
 	program_layout_update(p, p->last_layout, p->last_window, p->focus->owner_window);
 

--- a/xneur/lib/main/program.c
+++ b/xneur/lib/main/program.c
@@ -520,12 +520,12 @@ static void program_process_input(struct _program *p)
 				log_message(TRACE, _("Received MotionNotify (event type %d)"), type);
 				break;
 			}
-			case FocusIn:
 			case LeaveNotify:
 			case EnterNotify:
+				break;
+			case FocusIn:
 			{
-				if (((Window)p->focus->get_focused_window(p->focus) != (Window)p->focus->owner_window)
-				    && (type == FocusIn))
+				if (p->focus->is_focus_changed(p->focus))
 				{
 					log_message(TRACE, _("Received FocusIn on window %d (event type %d)"), p->event->event.xfocus.window, type);
 				}
@@ -533,8 +533,7 @@ static void program_process_input(struct _program *p)
 			}
 			case FocusOut:
 			{
-				if (((Window)p->focus->get_focused_window(p->focus) != (Window)p->focus->owner_window)
-				    && (type == FocusOut))
+				if (p->focus->is_focus_changed(p->focus))
 				{
 					log_message(TRACE, _("Received FocusOut on window %d (event type %d)"), p->event->event.xfocus.window, type);
 					program_update(p);
@@ -576,7 +575,7 @@ static void program_process_input(struct _program *p)
 							p->buffer->save_and_clear(p->buffer, p->focus->owner_window);
 							p->correction_buffer->clear(p->correction_buffer);
 							p->correction_action = CORRECTION_NONE;
-							if ((Window)p->focus->get_focused_window(p->focus) != (Window)p->focus->owner_window)
+							if (p->focus->is_focus_changed(p->focus))
 							{
 								program_update(p);
 							}

--- a/xneur/lib/main/program.c
+++ b/xneur/lib/main/program.c
@@ -247,18 +247,18 @@ static void fetch_window_name(char *text_to_find, Window window) {
 	free(app_name);
 }
 
-static void program_layout_update(struct _program *p)
+static void program_layout_update(struct _program *p, int layout, Window old_window, Window new_window)
 {
 	if (!xconfig->remember_layout)
 		return;
 
-	if ((Window) p->last_window == p->focus->owner_window)
+	if (old_window == new_window)
 		return;
 
 	char text_to_find[1024];
 	char window_layout[1024];
 
-	fetch_window_name(text_to_find, p->last_window);
+	fetch_window_name(text_to_find, old_window);
 	// Remove layout for old window
 	for (int lang = 0; lang < xconfig->handle->total_languages; lang++)
 	{
@@ -271,10 +271,10 @@ static void program_layout_update(struct _program *p)
 	}
 
 	// Save layout for old window
-	sprintf(window_layout, "%s %d", text_to_find, p->last_layout);
+	sprintf(window_layout, "%s %d", text_to_find, layout);
 	xconfig->window_layouts->add(xconfig->window_layouts, window_layout);
 
-	fetch_window_name(text_to_find, p->focus->owner_window);
+	fetch_window_name(text_to_find, new_window);
 
 	// Restore layout for new window
 	for (int lang = 0; lang < xconfig->handle->total_languages; lang++)
@@ -283,7 +283,6 @@ static void program_layout_update(struct _program *p)
 		if (!xconfig->window_layouts->exist(xconfig->window_layouts, window_layout, BY_PLAIN))
 			continue;
 
-		//XkbLockGroup(main_window->display, XkbUseCoreKbd, lang);
 		set_keyboard_group(lang);
 		log_message(DEBUG, _("Restore layout group to %d"), lang);
 		return;
@@ -309,7 +308,7 @@ static void program_update(struct _program *p)
 
 	p->focus->update_grab_events(p->focus, listen_mode);
 
-	program_layout_update(p);
+	program_layout_update(p, p->last_layout, p->last_window, p->focus->owner_window);
 
 	p->buffer->save_and_clear(p->buffer, p->last_window);
 	p->correction_buffer->clear(p->correction_buffer);

--- a/xneur/lib/main/program.c
+++ b/xneur/lib/main/program.c
@@ -331,6 +331,7 @@ static void program_update(struct _program *p)
 
 	// Can update `p->focus->owner_window`
 	int changed = p->focus->get_focus_status(p->focus, &p->app_forced_mode, &p->app_excluded, &p->app_autocompletion_mode);
+	p->focus->last_excluded = xconfig->tracking_input ? p->app_excluded : TRUE;
 
 	if (!changed)
 		return;

--- a/xneur/lib/main/program.c
+++ b/xneur/lib/main/program.c
@@ -337,7 +337,7 @@ static void program_update(struct _program *p)
 		return;
 
 	p->event->set_owner_window(p->event, p->focus->owner_window);
-	p->focus->update_grab_events(p->focus, p->app_excluded || (xconfig->tracking_input ? p->app_excluded : TRUE));
+	p->focus->update_grab_events(p->focus, p->app_excluded || !xconfig->tracking_input);
 
 	program_layout_update(p, p->last_layout, p->last_window, p->focus->owner_window);
 
@@ -835,7 +835,7 @@ static void program_on_key_action(struct _program *p, int type, KeySym key, int 
 			 || key == XK_Num_Lock
 			 || key == XK_Scroll_Lock
 			) {
-				p->focus->click_key(p->focus, key);
+				p->focus->click_key(p->focus, p->focus->last_excluded, key);
 			}
 		}
 

--- a/xneur/lib/main/program.c
+++ b/xneur/lib/main/program.c
@@ -835,7 +835,7 @@ static void program_on_key_action(struct _program *p, int type, KeySym key, int 
 			 || key == XK_Num_Lock
 			 || key == XK_Scroll_Lock
 			) {
-				p->focus->click_key(p->focus, !xconfig->tracking_input || p->app_excluded, key);
+				p->focus->click_key(p->focus, p->app_excluded, key);
 			}
 		}
 

--- a/xneur/lib/main/program.c
+++ b/xneur/lib/main/program.c
@@ -341,13 +341,13 @@ static void program_update(struct _program *p)
 	p->last_window = p->focus->owner_window;
 
 	// Can update `p->focus->owner_window`
-	int changed = p->focus->get_focus_status(p->focus, &p->app_forced_mode, &p->app_focus_mode, &p->app_autocompletion_mode);
+	int changed = p->focus->get_focus_status(p->focus, &p->app_forced_mode, &p->app_excluded, &p->app_autocompletion_mode);
 
 	if (!changed)
 		return;
 
 	p->event->set_owner_window(p->event, p->focus->owner_window);
-	p->focus->update_grab_events(p->focus, p->app_focus_mode != FOCUS_EXCLUDED);
+	p->focus->update_grab_events(p->focus, !p->app_excluded);
 
 	program_layout_update(p, p->last_layout, p->last_window, p->focus->owner_window);
 
@@ -910,7 +910,7 @@ static void program_perform_user_action(struct _program *p, int action)
 
 static void program_perform_auto_action(struct _program *p, int action)
 {
-	if (p->focus->last_focus == FOCUS_EXCLUDED)
+	if (p->focus->last_excluded)
 		return;
 
 	struct _buffer *string = p->buffer;

--- a/xneur/lib/main/program.c
+++ b/xneur/lib/main/program.c
@@ -269,17 +269,6 @@ static Bool is_modifier(KeySym key_sym)
 	return False;
 }
 
-static void click_key(KeySym keysym)
-{
-	KeyCode keycode = XKeysymToKeycode(main_window->display, keysym);
-
-	XTestFakeKeyEvent(main_window->display, keycode, TRUE, 0); // key press event
-	XTestFakeKeyEvent(main_window->display, keycode ,FALSE, 0); // key release event
-	XFlush(main_window->display);
-
-	return;
-}
-
 static void toggle_lock(int mask, int state)
 {
 	int xkb_opcode, xkb_event, xkb_error;
@@ -841,29 +830,11 @@ static void program_on_key_action(struct _program *p, int type, KeySym key, int 
 
 		if ((p->user_action >= 0) || (p->action != ACTION_NONE))
 		{
-			unsigned state;
-			XkbGetIndicatorState(main_window->display, XkbUseCoreKbd, &state);
-			if (key == XK_Caps_Lock)
-			{
-				//log_message(ERROR, "	Set Caps to %d", (state & 0x01)?0:1);
-				p->focus->update_grab_events(p->focus, FALSE);
-				//toggle_lock (main_window->keymap->capslock_mask, (state & 0x01)?0:1);
-				click_key (XK_Caps_Lock);
-				p->focus->update_grab_events(p->focus, TRUE);
-			}
-			if (key == XK_Num_Lock)
-			{
-				//log_message (ERROR, "Need reset Num");
-				p->focus->update_grab_events(p->focus, FALSE);
-				click_key (XK_Num_Lock);
-				p->focus->update_grab_events(p->focus, TRUE);
-			}
-			if (key == XK_Scroll_Lock)
-			{
-				//log_message (ERROR, "Need reset Scroll");
-				p->focus->update_grab_events(p->focus, FALSE);
-				click_key (XK_Scroll_Lock);
-				p->focus->update_grab_events(p->focus, TRUE);
+			if (key == XK_Caps_Lock
+			 || key == XK_Num_Lock
+			 || key == XK_Scroll_Lock
+			) {
+				p->focus->click_key(p->focus, key);
 			}
 		}
 

--- a/xneur/lib/main/program.c
+++ b/xneur/lib/main/program.c
@@ -331,7 +331,6 @@ static void program_update(struct _program *p)
 
 	// Can update `p->focus->owner_window`
 	int changed = p->focus->get_focus_status(p->focus, &p->app_forced_mode, &p->app_excluded, &p->app_autocompletion_mode);
-	p->focus->last_excluded = xconfig->tracking_input ? p->app_excluded : TRUE;
 
 	if (!changed)
 		return;
@@ -836,7 +835,7 @@ static void program_on_key_action(struct _program *p, int type, KeySym key, int 
 			 || key == XK_Num_Lock
 			 || key == XK_Scroll_Lock
 			) {
-				p->focus->click_key(p->focus, p->focus->last_excluded, key);
+				p->focus->click_key(p->focus, !xconfig->tracking_input || p->app_excluded, key);
 			}
 		}
 
@@ -882,7 +881,7 @@ static void program_perform_user_action(struct _program *p, int action)
 
 static void program_perform_auto_action(struct _program *p, int action)
 {
-	if (p->focus->last_excluded)
+	if (!xconfig->tracking_input || p->app_excluded)
 		return;
 
 	struct _buffer *string = p->buffer;

--- a/xneur/lib/main/program.c
+++ b/xneur/lib/main/program.c
@@ -347,12 +347,7 @@ static void program_update(struct _program *p)
 		return;
 
 	p->event->set_owner_window(p->event, p->focus->owner_window);
-
-	int listen_mode = LISTEN_GRAB_INPUT;
-	if (p->app_focus_mode == FOCUS_EXCLUDED)
-		listen_mode = LISTEN_DONTGRAB_INPUT;
-
-	p->focus->update_grab_events(p->focus, listen_mode);
+	p->focus->update_grab_events(p->focus, p->app_focus_mode != FOCUS_EXCLUDED);
 
 	program_layout_update(p, p->last_layout, p->last_window, p->focus->owner_window);
 
@@ -852,24 +847,24 @@ static void program_on_key_action(struct _program *p, int type, KeySym key, int 
 			if (key == XK_Caps_Lock)
 			{
 				//log_message(ERROR, "	Set Caps to %d", (state & 0x01)?0:1);
-				p->focus->update_grab_events(p->focus, LISTEN_DONTGRAB_INPUT);
+				p->focus->update_grab_events(p->focus, FALSE);
 				//toggle_lock (main_window->keymap->capslock_mask, (state & 0x01)?0:1);
 				click_key (XK_Caps_Lock);
-				p->focus->update_grab_events(p->focus, LISTEN_GRAB_INPUT);
+				p->focus->update_grab_events(p->focus, TRUE);
 			}
 			if (key == XK_Num_Lock)
 			{
 				//log_message (ERROR, "Need reset Num");
-				p->focus->update_grab_events(p->focus, LISTEN_DONTGRAB_INPUT);
+				p->focus->update_grab_events(p->focus, FALSE);
 				click_key (XK_Num_Lock);
-				p->focus->update_grab_events(p->focus, LISTEN_GRAB_INPUT);
+				p->focus->update_grab_events(p->focus, TRUE);
 			}
 			if (key == XK_Scroll_Lock)
 			{
 				//log_message (ERROR, "Need reset Scroll");
-				p->focus->update_grab_events(p->focus, LISTEN_DONTGRAB_INPUT);
+				p->focus->update_grab_events(p->focus, FALSE);
 				click_key (XK_Scroll_Lock);
-				p->focus->update_grab_events(p->focus, LISTEN_GRAB_INPUT);
+				p->focus->update_grab_events(p->focus, TRUE);
 			}
 		}
 
@@ -1019,9 +1014,6 @@ static void program_perform_auto_action(struct _program *p, int action)
 
 				return;
 			}
-
-			// Block events of keyboard (push to event queue)
-			//p->focus->update_events(p->focus, LISTEN_DONTGRAB_INPUT);
 
 			// Check two capital letter
 			program_check_tcl_last_word(p);
@@ -2310,8 +2302,6 @@ static void program_check_misprint(struct _program *p)
 	{
 		p->correction_action = CORRECTION_NONE;
 
-		//p->focus->update_events(p->focus, LISTEN_DONTGRAB_INPUT);
-
 		log_message (DEBUG, _("Found a misprint , correction '%s' to '%s'..."), word+offset, possible_word);
 
 		p->correction_buffer->set_content(p->correction_buffer, p->buffer->content);
@@ -2364,8 +2354,6 @@ static void program_check_misprint(struct _program *p)
 		p->buffer->set_offset(p->buffer, new_offset);
 		program_send_string_silent(p, 0);
 		p->buffer->unset_offset(p->buffer, new_offset);
-
-		//p->focus->update_events(p->focus, LISTEN_GRAB_INPUT);
 
 		int notify_text_len = strlen(_("Correction '%s' to '%s'")) + strlen(word+offset) + 1 + possible_word_len;
 		char *notify_text = (char *) malloc(notify_text_len * sizeof(char));
@@ -2775,8 +2763,6 @@ static void program_change_word(struct _program *p, enum _change_action action)
 		case CHANGE_STRING_TO_LAYOUT_3:
 		{
 			program_change_lang(p, action - CHANGE_STRING_TO_LAYOUT_0);
-			//p->focus->update_events(p->focus, LISTEN_DONTGRAB_INPUT);	// Disable receiving events
-
 			program_send_string_silent(p, p->buffer->cur_pos);
 			break;
 		}

--- a/xneur/lib/main/program.c
+++ b/xneur/lib/main/program.c
@@ -340,9 +340,10 @@ static void program_update(struct _program *p)
 {
 	p->last_window = p->focus->owner_window;
 
-	int status = p->focus->get_focus_status(p->focus, &p->app_forced_mode, &p->app_focus_mode, &p->app_autocompletion_mode);
+	// Can update `p->focus->owner_window`
+	int changed = p->focus->get_focus_status(p->focus, &p->app_forced_mode, &p->app_focus_mode, &p->app_autocompletion_mode);
 
-	if (status == FOCUS_UNCHANGED)
+	if (!changed)
 		return;
 
 	p->event->set_owner_window(p->event, p->focus->owner_window);
@@ -358,9 +359,6 @@ static void program_update(struct _program *p)
 	p->buffer->save_and_clear(p->buffer, p->last_window);
 	p->correction_buffer->clear(p->correction_buffer);
 	p->correction_action = CORRECTION_NONE;
-
-	if (status == FOCUS_NONE)
-		return;
 
 	// Сброс признака "ручное переключение" после смены фокуса.
 	p->changed_manual = MANUAL_FLAG_UNSET;

--- a/xneur/lib/main/program.c
+++ b/xneur/lib/main/program.c
@@ -337,7 +337,7 @@ static void program_update(struct _program *p)
 		return;
 
 	p->event->set_owner_window(p->event, p->focus->owner_window);
-	p->focus->update_grab_events(p->focus, p->app_excluded || p->focus->last_excluded);
+	p->focus->update_grab_events(p->focus, p->app_excluded || (xconfig->tracking_input ? p->app_excluded : TRUE));
 
 	program_layout_update(p, p->last_layout, p->last_window, p->focus->owner_window);
 

--- a/xneur/lib/main/program.c
+++ b/xneur/lib/main/program.c
@@ -325,28 +325,27 @@ static void program_layout_update(struct _program *p, int layout, Window old_win
 	log_message(DEBUG, _("Store default layout group to %d"), xconfig->default_group);
 }
 
-static void program_update(struct _program *p)
+static Window program_update(struct _program *p)
 {
-	p->last_window = p->focus->owner_window;
+	Window prev = p->focus->owner_window;
 
 	// Can update `p->focus->owner_window`
 	int changed = p->focus->get_focus_status(p->focus, &p->app_forced_mode, &p->app_excluded, &p->app_autocompletion_mode);
+	if (changed) {
+		p->event->set_owner_window(p->event, p->focus->owner_window);
+		// If application is excluded from tracking, disable grabbing input, otherwise enable
+		p->focus->update_grab_events(p->focus, !p->app_excluded);
 
-	if (!changed)
-		return;
+		program_layout_update(p, p->last_layout, prev, p->focus->owner_window);
 
-	p->event->set_owner_window(p->event, p->focus->owner_window);
-	// If application is excluded from tracking, disable grabbing input, otherwise enable
-	p->focus->update_grab_events(p->focus, !p->app_excluded);
+		p->buffer->save_and_clear(p->buffer, prev);
+		p->correction_buffer->clear(p->correction_buffer);
+		p->correction_action = CORRECTION_NONE;
 
-	program_layout_update(p, p->last_layout, p->last_window, p->focus->owner_window);
-
-	p->buffer->save_and_clear(p->buffer, p->last_window);
-	p->correction_buffer->clear(p->correction_buffer);
-	p->correction_action = CORRECTION_NONE;
-
-	// Сброс признака "ручное переключение" после смены фокуса.
-	p->changed_manual = MANUAL_FLAG_UNSET;
+		// Сброс признака "ручное переключение" после смены фокуса.
+		p->changed_manual = MANUAL_FLAG_UNSET;
+	}
+	return prev;
 }
 
 static void process_key(struct _program *p, int main_type, int type, const char* message) {
@@ -372,14 +371,14 @@ static void process_key(struct _program *p, int main_type, int type, const char*
 
 static void program_process_input(struct _program *p)
 {
-	program_update(p);
+	Window prev = program_update(p);
 
 	while (1)
 	{
 		int type = p->event->get_next_event(p->event);
 
 		int curr_layout = get_curr_keyboard_group();
-		if ((p->last_layout != curr_layout) && (p->last_window == p->focus->owner_window))
+		if ((p->last_layout != curr_layout) && prev == p->focus->owner_window)
 		{
 			if (xconfig->troubleshoot_switch)
 			{
@@ -526,7 +525,7 @@ static void program_process_input(struct _program *p)
 				if (p->focus->is_focus_changed(p->focus))
 				{
 					log_message(TRACE, _("Received FocusOut on window %d (event type %d)"), p->event->event.xfocus.window, type);
-					program_update(p);
+					prev = program_update(p);
 				}
 				break;
 			}
@@ -567,9 +566,9 @@ static void program_process_input(struct _program *p)
 							p->correction_action = CORRECTION_NONE;
 							if (p->focus->is_focus_changed(p->focus))
 							{
-								program_update(p);
+								prev = program_update(p);
 							}
-							log_message(TRACE, _("Received XI_ButtonPress (button %d) (event type %d, subtype %d)"), xi_event->detail, type, xi_event->evtype);
+							log_message(TRACE, _("Received XI_RawButtonPress (button %d) (event type %d, subtype %d)"), xi_event->detail, type, xi_event->evtype);
 							//}
 							break;
 						}

--- a/xneur/lib/main/program.c
+++ b/xneur/lib/main/program.c
@@ -337,7 +337,8 @@ static void program_update(struct _program *p)
 		return;
 
 	p->event->set_owner_window(p->event, p->focus->owner_window);
-	p->focus->update_grab_events(p->focus, p->app_excluded || !xconfig->tracking_input);
+	// If application is excluded from tracking, disable grabbing input, otherwise enable
+	p->focus->update_grab_events(p->focus, !p->app_excluded && xconfig->tracking_input);
 
 	program_layout_update(p, p->last_layout, p->last_window, p->focus->owner_window);
 

--- a/xneur/lib/main/program.c
+++ b/xneur/lib/main/program.c
@@ -337,7 +337,7 @@ static void program_update(struct _program *p)
 
 	p->event->set_owner_window(p->event, p->focus->owner_window);
 	// If application is excluded from tracking, disable grabbing input, otherwise enable
-	p->focus->update_grab_events(p->focus, !p->app_excluded && xconfig->tracking_input);
+	p->focus->update_grab_events(p->focus, !p->app_excluded);
 
 	program_layout_update(p, p->last_layout, p->last_window, p->focus->owner_window);
 

--- a/xneur/lib/main/program.c
+++ b/xneur/lib/main/program.c
@@ -337,7 +337,7 @@ static void program_update(struct _program *p)
 		return;
 
 	p->event->set_owner_window(p->event, p->focus->owner_window);
-	p->focus->update_grab_events(p->focus, p->app_excluded);
+	p->focus->update_grab_events(p->focus, p->app_excluded || p->focus->last_excluded);
 
 	program_layout_update(p, p->last_layout, p->last_window, p->focus->owner_window);
 

--- a/xneur/lib/main/program.h
+++ b/xneur/lib/main/program.h
@@ -32,7 +32,7 @@ struct _program
 	int  last_action;
 	int  changed_manual;
 	int  app_forced_mode;
-	int  app_focus_mode;
+	int  app_excluded;
 	int  app_autocompletion_mode;
 
 	int  action_mode;

--- a/xneur/lib/main/program.h
+++ b/xneur/lib/main/program.h
@@ -38,7 +38,6 @@ struct _program
 	int  action_mode;
 
 	int  last_layout;
-	Window  last_window;
 
 	int user_action;
 	enum _hotkey_action action;

--- a/xneur/lib/main/utils.h
+++ b/xneur/lib/main/utils.h
@@ -20,16 +20,9 @@
 #ifndef _UTILS_H_
 #define _UTILS_H_
 
-#include <X11/XKBlib.h>
-#include <X11/extensions/XInput2.h>
 #include <X11/extensions/XTest.h>
 
-Bool is_modifier(KeySym key_sym);
 char*  get_wm_class_name(Window window);
-void   grab_button(int is_grab);
-void   grab_all_keys(Window window, int is_grab);
 unsigned char *get_win_prop(Display *display, Window window, Atom atom, unsigned long *nitems);
-void toggle_lock(int mask, int state);
-void click_key(KeySym keysym);
 
 #endif /* _UTILS_H_ */

--- a/xneur/po/ru.po
+++ b/xneur/po/ru.po
@@ -1467,12 +1467,6 @@ msgstr "Текущие данные окна очищены"
 #~ msgid "Failed to %s keyboard with error BadWindow"
 #~ msgstr "Ошибка BadWindow при %s клавиатуры"
 
-#~ msgid "Interception of events in the window (ID %d) with name '%s' OFF"
-#~ msgstr "Перехват событий в окне (ID %d) с именем '%s' выключен"
-
-#~ msgid "Interception of events in the window (ID %d) with name '%s' ON"
-#~ msgstr "Перехват событий в окне (ID %d) с именем '%s' включен"
-
 #~ msgid "Received XI_ButtonRelease (event type %d, subtype %d)"
 #~ msgstr "Получено XI_ButtonRelease(тип события %d, подтип %d)"
 


### PR DESCRIPTION
В целом рефакторинг касался того, чтобы понять назначение отдельных полей структуры `_focus` и связанных констант/макроопределений и т.п., и в итоге часть из них была удалена за ненадобностью, а назначение остальных стало, как мне кажется, более ясным.

Часть функций были перенесены из файла `utils.c` в файлы, где они используются.

Удалены поля `_focus::last_excluded` и `_program::last_window`.

Некоторый повторяющийся код выделен в функции.

Коммитов много, но около десятка из них тривиальные и предназначены для иллюстрирования процесса избавления от `_focus::last_excluded`