### PR TITLE
Исправлены все предупреждения clang-tidy

### DIFF
--- a/xneur/lib/ai/conversion.c
+++ b/xneur/lib/ai/conversion.c
@@ -26,7 +26,7 @@
 
 #include "conversion.h"
 
-static unsigned short codes[] =
+static unsigned short UTF8_CODES[] =
 {
 	// ё й ц у к е н г ш щ з х
 	0x91D1, 0xB9D0, 0x86D1, 0x83D1, 0xBAD0, 0xB5D0, 0xBDD0, 0xB3D0, 0x88D1, 0x89D1, 0xB7D0, 0x85D1,
@@ -49,47 +49,47 @@ static unsigned short codes[] =
 	// ѓ, Ѓ, ј, Ј, ќ, Ќ, љ, Љ
 	0x93D1, 0x83D0, 0x98D1, 0x88D0, 0x9CD1, 0x8CD0, 0x99D1, 0x89D0,
 	// њ, Њ, џ, Џ, ѣ, Ѣ, ѳ, Ѳ
-	0x9AD1, 0x8AD0, 0x9FD1, 0x8FD0, 0xA3D1, 0xA2D1, 0xB3D1, 0xB2D1 
+	0x9AD1, 0x8AD0, 0x9FD1, 0x8FD0, 0xA3D1, 0xA2D1, 0xB3D1, 0xB2D1
 };
 
 static const char *translit[] =
 {
 	// ё й ц у к е н г ш щ з х
-	"yo\0", "y\0", "ts\0", "u\0", "k\0", "e\0", "n\0", "g\0", "sh\0", "sch\0", "z\0", "h\0",
+	"yo", "y", "ts", "u", "k", "e", "n", "g", "sh", "sch", "z", "h",
 	// ъ ф ы в а п р о л д ж э
-	"``\0", "f\0", "y`\0", "v\0", "a\0", "p\0", "r\0", "o\0", "l\0", "d\0", "zh\0", "e`\0",
+	"``", "f", "y`", "v", "a", "p", "r", "o", "l", "d", "zh", "e`",
 	// я ч с м и т ь б ю Ё Й Ц
-	"ya\0", "ch\0", "s\0", "m\0", "i\0", "t\0", "\'\0", "b\0", "yu\0", "Yo\0", "Y\0", "Ts\0",
+	"ya", "ch", "s", "m", "i", "t", "\'", "b", "yu", "Yo", "Y", "Ts",
 	// У К Е Н Г Ш Щ З Х Ъ Ф Ы
-	"U\0", "K\0", "E\0", "N\0", "G\0", "Sh\0", "Sch\0", "Z\0", "H\0", "``\0", "F\0", "Y`\0",
+	"U", "K", "E", "N", "G", "Sh", "Sch", "Z", "H", "``", "F", "Y`",
 	// В А П Р О Л Д Ж Э Я Ч С
-	"V\0", "A\0", "P\0", "R\0", "O\0", "L\0", "D\0", "Zh\0", "E`\0", "Ya\0", "Ch\0", "S\0",
+	"V", "A", "P", "R", "O", "L", "D", "Zh", "E`", "Ya", "Ch", "S",
 	// М И Т Ь Б Ю
-	"M\0", "I\0", "T\0", "\'\0", "B\0", "Yu\0",
+	"M", "I", "T", "\'", "B", "Yu",
 	// №
-	"#\0",
+	"#",
 	// ґ, Ґ, є, Є, і, І, ї, Ї
-	"g`\0", "G`\0", "ye\0", "Ye\0", "i\0", "I\0", "yi\0", "Yi\0",
+	"g`", "G`", "ye", "Ye", "i", "I", "yi", "Yi",
 	// ў, Ў
-	"u`\0", "U`\0",
+	"u`", "U`",
 	// ѓ, Ѓ, ј, Ј, ќ, Ќ, љ, Љ
-	"g`\0", "G`\0", "j\0", "J\0", "k`\0", "K`\0", "l`\0", "L`\0",
+	"g`", "G`", "j", "J", "k`", "K`", "l`", "L`",
 	// њ, Њ, џ, Џ, ѣ, Ѣ, ѳ, Ѳ
-	"n`\0", "N`\0", "dh\0", "Dh\0", "ye\0", "Ye\0", "fh\0", "Fh\0"
+	"n`", "N`", "dh", "Dh", "ye", "Ye", "fh", "Fh"
 };
 
 
-static const int codes_len = sizeof(codes) / sizeof(codes[0]);
+static const int codes_len = sizeof(UTF8_CODES) / sizeof(UTF8_CODES[0]);
 
 static const char* get_translit(const char *sym)
 {
 	for (int i = 0; i < codes_len; i++)
 	{
 		unsigned short usym = *(unsigned short*) sym;
-		if (codes[i] == usym)
+		if (UTF8_CODES[i] == usym)
 			return translit[i];
 	}
-	return NULLSYM;
+	return NULL;
 }
 
 /*static char* get_revert_translit(const char *sym, unsigned int len)
@@ -98,16 +98,16 @@ static const char* get_translit(const char *sym)
 	{
 		if (strlen(translit[i]) != len)
 			continue;
-		if (strcmp(translit[i], sym) == 0) 
+		if (strcmp(translit[i], sym) == 0)
 		{
-			//log_message (ERROR, "%s", (char*)&codes[i]);
+			//log_message (ERROR, "%s", (char*)&UTF8_CODES[i]);
 			char* tmp = malloc (sizeof(unsigned short) + 1);
 			memset(tmp, NULLSYM, sizeof(unsigned short) + 1);
-			strncpy(tmp, (char*)codes+i*sizeof(codes[0]), sizeof(unsigned short));
-			//tmp[sizeof(codes[0])] = NULLSYM;
+			strncpy(tmp, (char*)UTF8_CODES+i*sizeof(UTF8_CODES[0]), sizeof(unsigned short));
+			//tmp[sizeof(UTF8_CODES[0])] = NULLSYM;
 			log_message (ERROR, "----%s-----", tmp);
 			free(tmp);
-			return (char*)codes+i;
+			return (char*)UTF8_CODES+i;
 		}
 	}
 	return NULLSYM;
@@ -115,12 +115,13 @@ static const char* get_translit(const char *sym)
 
 void convert_text_to_translit(char **work_text)
 {
-	char *text = *work_text;
-	int j = 0, len = strlen(text);
+	const char *text = *work_text;
+	size_t j = 0, len = strlen(text);
 
-	char *trans_text = (char *) malloc((len * 3 + 1) * sizeof(char));
+	const size_t TRANSLIT_CHAR_SIZE = sizeof(translit[0])-1;// -1 for \0
+	char *trans_text = (char *) malloc((len * TRANSLIT_CHAR_SIZE + 1) * sizeof(char));
 
-	for (int i = 0; i < len; i++)
+	for (size_t i = 0; i < len; ++i)
 	{
 		if (isascii(text[i]))
 		{
@@ -139,7 +140,7 @@ void convert_text_to_translit(char **work_text)
 
 			// Without revert translit here
 			trans_text[j++] = text[i];
-			
+
 			continue;
 		}
 
@@ -149,19 +150,19 @@ void convert_text_to_translit(char **work_text)
 		{
 			if (isascii(text[i + 1]))
 				break;
-			if (get_translit(&text[i + 1]) != NULLSYM)
+			if (get_translit(&text[i + 1]) != NULL)
 				break;
 		}
 
-		while (*new_symbol != NULLSYM)
+		while (*new_symbol != NULL)
 		{
 			trans_text[j++] = *new_symbol;
 			new_symbol++;
 		}
 	}
 
-	trans_text[j] = NULLSYM;
+	trans_text[j] = '\0';
 
 	free(*work_text);
-	*work_text = trans_text; 
+	*work_text = trans_text;
 }

--- a/xneur/lib/ai/conversion.c
+++ b/xneur/lib/ai/conversion.c
@@ -83,9 +83,9 @@ static const int codes_len = sizeof(UTF8_CODES) / sizeof(UTF8_CODES[0]);
 
 static const char* get_translit(const char *sym)
 {
+	unsigned short usym = *(unsigned short*) sym;
 	for (int i = 0; i < codes_len; i++)
 	{
-		unsigned short usym = *(unsigned short*) sym;
 		if (UTF8_CODES[i] == usym)
 			return translit[i];
 	}
@@ -113,6 +113,7 @@ static const char* get_translit(const char *sym)
 	return NULLSYM;
 }*/
 
+/// FIXME: Works only for Russian language
 void convert_text_to_translit(char **work_text)
 {
 	const char *text = *work_text;
@@ -145,19 +146,17 @@ void convert_text_to_translit(char **work_text)
 		}
 
 		const char *new_symbol = get_translit(&text[i]);
-
-		for(; i < len - 1; i++)
-		{
-			if (isascii(text[i + 1]))
-				break;
-			if (get_translit(&text[i + 1]) != NULL)
-				break;
-		}
-
-		while (*new_symbol != NULL)
-		{
-			trans_text[j++] = *new_symbol;
-			new_symbol++;
+		if (new_symbol != NULL) {
+			// Each translitirated symbol occupies 2 bytes, so need to consume one more byte
+			++i;
+			while (*new_symbol)
+			{
+				trans_text[j++] = *new_symbol;
+				new_symbol++;
+			}
+		} else {
+			// If symbol can't be translitirated, use as is
+			trans_text[j++] = text[i];
 		}
 	}
 

--- a/xneur/lib/ai/detection.c
+++ b/xneur/lib/ai/detection.c
@@ -203,6 +203,7 @@ static int get_proto_lang(struct _xneur_handle *handle, char **word, int **sym_l
 		? cur_l->proto
 		: cur_l->big_proto;
 
+	// NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): clang-tidy false-positive uninitialized access
 	int hits = get_proto_hits(cur_proto, proto_len, word[cur_lang], sym_len[cur_lang], len, offset);
 	if (hits == 0)
 	{
@@ -222,6 +223,7 @@ static int get_proto_lang(struct _xneur_handle *handle, char **word, int **sym_l
 		if (lang == cur_lang || l->disable_auto_detection || l->excluded)
 			continue;
 
+		// NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): clang-tidy false-positive uninitialized access
 		if (strlen(word[lang]) == 0)
 			continue;
 
@@ -428,6 +430,7 @@ int check_lang(struct _xneur_handle *handle, struct _buffer *p, int cur_lang, in
 
 	for (int i = 0; i < handle->total_languages; i++)
 	{
+		// NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): clang-tidy false-positive uninitialized access
 		free(word_base[i]);
 		free(word_unchanged_base[i]);
 	}

--- a/xneur/lib/ai/detection.c
+++ b/xneur/lib/ai/detection.c
@@ -371,22 +371,23 @@ int check_lang(struct _xneur_handle *handle, struct _buffer *p, int cur_lang, in
 	log_message(DEBUG, _("Processing word:"));
 	for (int i = 0; i < handle->total_languages; i++)
 	{
-		word[i] = strdup(p->get_last_word(p, p->i18n_content[i].content));
-		word_base[i] = word[i];
-		del_final_numeric_char(word[i]);
+		char* last_word           = strdup(p->get_last_word(p, p->i18n_content[i].content));
+		char* last_word_unchanged = strdup(p->get_last_word(p, p->i18n_content[i].content_unchanged));
+		del_final_numeric_char(last_word);
+		del_final_numeric_char(last_word_unchanged);
 
-		unsigned int offset = 0;
-		for (offset = 0; offset < strlen(word[i]); offset++)
+		// Offset of first non-punctuation or digit symbol
+		size_t offset = 0;
+		for (; offset < strlen(last_word); ++offset)
 		{
-			if (!ispunct(word[i][offset]) && (!isdigit(word[i][offset])))
+			if (!ispunct(last_word[offset]) && (!isdigit(last_word[offset])))
 				break;
 		}
-		word[i] = word[i] + offset;
+		word[i] = last_word + offset;
+		word_base[i] = last_word;
 
-		word_unchanged[i] = strdup(p->get_last_word(p, p->i18n_content[i].content_unchanged));
-		word_unchanged_base[i] = word_unchanged[i];
-		word_unchanged[i] = word_unchanged[i] + offset;
-		del_final_numeric_char(word_unchanged[i]);
+		word_unchanged[i] = last_word_unchanged + offset;
+		word_unchanged_base[i] = last_word_unchanged;
 
 		log_message(DEBUG, _("   '%s' on layout '%s'"), word_unchanged[i], handle->languages[i].dir);
 

--- a/xneur/lib/ai/detection.c
+++ b/xneur/lib/ai/detection.c
@@ -362,11 +362,11 @@ static int get_similar_words(struct _xneur_handle *handle, struct _buffer *p)
 
 int check_lang(struct _xneur_handle *handle, struct _buffer *p, int cur_lang, int check_similar_words)
 {
-	char **word = (char **) malloc((handle->total_languages + 1) * sizeof(char *));
-	char **word_base = (char **) malloc((handle->total_languages + 1) * sizeof(char *));
-	char **word_unchanged = (char **) malloc((handle->total_languages + 1) * sizeof(char *));
-	char **word_unchanged_base = (char **) malloc((handle->total_languages + 1) * sizeof(char *));
-	int **sym_len = (int **) malloc((handle->total_languages + 1) * sizeof(int *));
+	char **word = (char **) malloc(handle->total_languages * sizeof(char *));
+	char **word_base = (char **) malloc(handle->total_languages * sizeof(char *));
+	char **word_unchanged = (char **) malloc(handle->total_languages * sizeof(char *));
+	char **word_unchanged_base = (char **) malloc(handle->total_languages * sizeof(char *));
+	int **sym_len = (int **) malloc(handle->total_languages * sizeof(int *));
 
 	log_message(DEBUG, _("Processing word:"));
 	for (int i = 0; i < handle->total_languages; i++)

--- a/xneur/lib/config/xnconfig.c
+++ b/xneur/lib/config/xnconfig.c
@@ -1113,7 +1113,6 @@ static int parse_config_file(struct _xneur_config *p, const char *dir_name, cons
 
 static void free_structures(struct _xneur_config *p)
 {
-	p->window_layouts->uninit(p->window_layouts);
 	p->manual_apps->uninit(p->manual_apps);
 	p->auto_apps->uninit(p->auto_apps);
 	p->layout_remember_apps->uninit(p->layout_remember_apps);
@@ -1280,7 +1279,6 @@ static void xneur_config_clear(struct _xneur_config *p)
 {
 	free_structures(p);
 
-	p->window_layouts		= list_char_init();
 	p->manual_apps			= list_char_init();
 	p->auto_apps			= list_char_init();
 	p->layout_remember_apps		= list_char_init();
@@ -1830,7 +1828,6 @@ struct _xneur_config* xneur_config_init(void)
 	p->dont_send_key_release_apps = list_char_init();
 	p->delay_send_key_apps	= list_char_init();
 
-	p->window_layouts		= list_char_init();
 	p->abbreviations		= list_char_init();
 	p->autocompletion_excluded_apps	= list_char_init();
 	p->plugins		= list_char_init();

--- a/xneur/lib/config/xnconfig.c
+++ b/xneur/lib/config/xnconfig.c
@@ -169,15 +169,9 @@ static void parse_hotkey(char **line, struct _xneur_hotkey * hotkey)
 	// When get_word returns the last part of string, *line became NULL
 	while (*line)
 	{
-		char *oldline = NULL;
-		if (*line)
-		{
-			oldline = strdup(*line);
-		}
 		const char *modifier = get_word(line);
 		if (modifier[0] == '\0')
 		{
-			free(oldline);
 			continue;
 		}
 
@@ -190,24 +184,16 @@ static void parse_hotkey(char **line, struct _xneur_hotkey * hotkey)
 		{
 			// The word is really modifier
 			hotkey->modifiers |= (1 << index);
-			//log_message(DEBUG, _("Adding modifier: '%s'"),modifier);
-			free(oldline);
+			continue;
 		}
-		else if (hotkey->key == NULL)
+		if (hotkey->key == NULL)
 		{
 			// The word is not modifier, it is a key and it is first non-modifier word
 			hotkey->key = strdup(modifier);
-			//log_message(DEBUG, _("Key set to: '%s'"),modifier);
-			free(oldline);
+			continue;
 		}
-		else
-		{
-			// The word is not modified and key is already been readed
-			*line = oldline;
-			//if (oldline)
-			//	log_message(DEBUG, _("Restoring old line: '%s'"),oldline);
-			return;
-		}
+		// The word is not a modifier and key has already been read
+		return;
 	}
 }
 
@@ -232,7 +218,9 @@ static void parse_line(struct _xneur_config *p, char *line)
 		return;
 	}
 
+	// String after option name to the end of string
 	char *full_string = strdup(line);
+	// Substring up to the first space
 	char *param = get_word(&line);
 
 	switch (index)
@@ -269,23 +257,6 @@ static void parse_line(struct _xneur_config *p, char *line)
 				parse_hotkey(&line, &(new_action->hotkey));
 				new_action->action = action;
 			}
-			/*
-			if (p->hotkeys[action].key == NULL)
-			{
-			        parse_hotkey(&line, &(p->hotkeys[action]));
-			}
-			else
-			{
-				log_message(WARNING, _("More than one hotkey specified for action '%s'"),param);
-				struct _xneur_action * new_action = one_more_user_action(p);
-				if (new_action != NULL)
-				{
-					parse_hotkey(&line, &(new_action->hotkey));
-					new_action->standard_action = action;
-					new_action->name = strdup(param);
-				}
-			}*/
-
 			break;
 		}
 		case 3: // Get Log Level
@@ -555,36 +526,35 @@ static void parse_line(struct _xneur_config *p, char *line)
 			if (new_user_action == NULL)
 				break;
 
-			char *whole_string = full_string;
-			parse_hotkey(&whole_string,&(new_user_action->hotkey));
-			line = whole_string;
+			line = full_string;
+			// Parse hotkey from line, move line pointer to after hotkey
+			parse_hotkey(&line, &(new_user_action->hotkey));
 
 			if (line != NULL)
 			{
-				char *cmd = strstr(line, USR_CMD_START);
-				if (cmd == NULL)
+				const char* s = strstr(line, USR_CMD_START);
+				// If <cmd> tag is not found, treat the whole string as a command
+				if (s == NULL)
 				{
 					new_user_action->name = NULL;
 					new_user_action->command = strdup(line);
 					break;
 				}
-				int len = strlen(line) - strlen(cmd);
-				new_user_action->name = strdup(line);
-				new_user_action->name[len - 1] = NULLSYM;
 
-				new_user_action->command = strdup(cmd + strlen(USR_CMD_START)*sizeof(char));
-				cmd = strstr(cmd + strlen(USR_CMD_START)*sizeof(char), USR_CMD_END);
-				if (cmd == NULL)
+				// Copy data from start of string up to start of <cmd> tag
+				new_user_action->name = strndup(line, s - line);
+				// Move to end of <cmd> tag
+				s += sizeof(USR_CMD_START) / sizeof(char) - 1;
+
+				const char* e = strstr(s, USR_CMD_END);
+				if (e == NULL)
 				{
-					free(new_user_action->command);
 					new_user_action->command = NULL;
 					break;
 				}
-				len = strlen(new_user_action->command) - strlen(cmd);
-				new_user_action->command[len] = NULLSYM;
-				free(line);
+				// Copy data from end of <cmd> tag up to start of </cmd> tag
+				new_user_action->command = strndup(s, e - s);
 			}
-
 			break;
 		}
 		case 28: // Show OSD

--- a/xneur/lib/config/xnconfig.c
+++ b/xneur/lib/config/xnconfig.c
@@ -107,7 +107,7 @@ static char* get_word(char **string)
 #define get_option_index(options, option) \
 	get_option_index_size(options, option, sizeof(options) / sizeof(options[0]));
 
-static int get_option_index_size(const char *options[], char *option, int options_count)
+static int get_option_index_size(const char *options[], const char *option, int options_count)
 {
 	for (int i = 0; i < options_count; i++)
 	{
@@ -166,17 +166,15 @@ static void parse_hotkey(char **line, struct _xneur_hotkey * hotkey)
 	//log_message(DEBUG, _("Parsing hotkey from: '%s'"),*line);
 
 	hotkey->key = NULL;
-	while (TRUE)
+	// When get_word returns the last part of string, *line became NULL
+	while (*line)
 	{
 		char *oldline = NULL;
 		if (*line)
 		{
 			oldline = strdup(*line);
 		}
-		char *modifier = get_word(line);
-		if (modifier == NULL)
-			break;
-
+		const char *modifier = get_word(line);
 		if (modifier[0] == '\0')
 		{
 			free(oldline);
@@ -218,7 +216,7 @@ static void parse_line(struct _xneur_config *p, char *line)
 	if (line[0] == '#')
 		return;
 
-	char *option = get_word(&line);
+	const char *option = get_word(&line);
 
 	int index = get_option_index(option_names, option);
 	if (index == -1)
@@ -227,6 +225,7 @@ static void parse_line(struct _xneur_config *p, char *line)
 		return;
 	}
 
+	// Parameter is missing after option name
 	if (line == NULL)
 	{
 		log_message(WARNING, _("Param mismatch for option %s"), option);
@@ -235,13 +234,6 @@ static void parse_line(struct _xneur_config *p, char *line)
 
 	char *full_string = strdup(line);
 	char *param = get_word(&line);
-
-	if (param == NULL)
-	{
-		free(full_string);
-		log_message(WARNING, _("Param mismatch for option %s"), option);
-		return;
-	}
 
 	switch (index)
 	{

--- a/xneur/lib/config/xnconfig.h
+++ b/xneur/lib/config/xnconfig.h
@@ -200,7 +200,6 @@ struct _xneur_config
 	struct _list_char *dont_send_key_release_apps;
 	struct _list_char *delay_send_key_apps;
 
-	struct _list_char *window_layouts;
 	struct _list_char *abbreviations;
 	struct _list_char *plugins;
 

--- a/xneur/lib/config/xnconfig_files.c
+++ b/xneur/lib/config/xnconfig_files.c
@@ -153,29 +153,28 @@ char* get_home_file_path_name(const char *dir_name, const char *file_name)
 			return NULL;
 		}
 		char *dir = strdup(dir_name);
-		char *dir_part = strsep(&dir, DIR_SEPARATOR);
+		char* iter = dir;
+		char *dir_part = strsep(&iter, DIR_SEPARATOR);
 		snprintf(path_file, max_path_len, "%s/%s/%s", getenv("HOME"), HOME_CONF_DIR, dir_part);
 		if (mkdir(path_file, mode) != 0 && errno != EEXIST)
 		{
 			free(path_file);
-			free(dir_part);
 			free(dir);
 			return NULL;
 		}
-		while (dir != NULL)
+		while (iter != NULL)
 		{
 			path_file = strcat(path_file, DIR_SEPARATOR);
-			char *dir_part = strsep(&dir, DIR_SEPARATOR);
+			char *dir_part = strsep(&iter, DIR_SEPARATOR);
 			path_file = strcat(path_file, dir_part);
 			if (mkdir(path_file, mode) != 0 && errno != EEXIST)
 			{
 				free(path_file);
-				free(dir_part);
 				free(dir);
 				return NULL;
 			}
 		}
-		free(dir_part);
+		free(dir);
 
 		if (mkdir(path_file, mode) != 0 && errno != EEXIST)
 		{

--- a/xneur/lib/config/xnconfig_files.c
+++ b/xneur/lib/config/xnconfig_files.c
@@ -136,37 +136,41 @@ char* get_home_file_path_name(const char *dir_name, const char *file_name)
 
 	if (dir_name == NULL)
 	{
-		snprintf(path_file, max_path_len, "%s/%s", getenv("HOME"), HOME_CONF_DIR);
-		if (mkdir(path_file, mode) != 0 && errno != EEXIST)
+		int written = snprintf(path_file, max_path_len, "%s/%s", getenv("HOME"), HOME_CONF_DIR);
+		if (written <= 0 || (mkdir(path_file, mode) != 0 && errno != EEXIST))
 		{
 			free(path_file);
 			return NULL;
 		}
-		snprintf(path_file, max_path_len, "%s/%s/%s", getenv("HOME"), HOME_CONF_DIR, file_name);
+		snprintf(path_file, max_path_len - written, "%s/%s/%s", getenv("HOME"), HOME_CONF_DIR, file_name);
 	}
 	else
 	{
-		snprintf(path_file, max_path_len, "%s/%s", getenv("HOME"), HOME_CONF_DIR);
-		if (mkdir(path_file, mode) != 0 && errno != EEXIST)
+		int written = snprintf(path_file, max_path_len, "%s/%s", getenv("HOME"), HOME_CONF_DIR);
+		if (written <= 0 || (mkdir(path_file, mode) != 0 && errno != EEXIST))
 		{
 			free(path_file);
 			return NULL;
 		}
+		max_path_len -= written;
 		char *dir = strdup(dir_name);
 		char* iter = dir;
 		char *dir_part = strsep(&iter, DIR_SEPARATOR);
-		snprintf(path_file, max_path_len, "%s/%s/%s", getenv("HOME"), HOME_CONF_DIR, dir_part);
-		if (mkdir(path_file, mode) != 0 && errno != EEXIST)
+		written = snprintf(path_file, max_path_len, "%s/%s/%s", getenv("HOME"), HOME_CONF_DIR, dir_part);
+		if (written <= 0 || (mkdir(path_file, mode) != 0 && errno != EEXIST))
 		{
 			free(path_file);
 			free(dir);
 			return NULL;
 		}
+		max_path_len -= written;
 		while (iter != NULL)
 		{
-			path_file = strcat(path_file, DIR_SEPARATOR);
+			path_file = strncat(path_file, DIR_SEPARATOR, max_path_len);
+			max_path_len -= sizeof(DIR_SEPARATOR) / sizeof(char);
 			char *dir_part = strsep(&iter, DIR_SEPARATOR);
-			path_file = strcat(path_file, dir_part);
+			path_file = strncat(path_file, dir_part, max_path_len);
+			max_path_len -= strlen(dir_part);
 			if (mkdir(path_file, mode) != 0 && errno != EEXIST)
 			{
 				free(path_file);

--- a/xneur/lib/lib/xneur.h
+++ b/xneur/lib/lib/xneur.h
@@ -34,9 +34,6 @@
 
 extern struct _window *main_window;
 
-extern int has_x_input_extension;
-extern int xi_opcode;
-
 struct _xneur_language
 {
 	char *dir;

--- a/xneur/lib/lib/xneurlib.c
+++ b/xneur/lib/lib/xneurlib.c
@@ -51,9 +51,6 @@
 
 struct _window *main_window;
 
-int has_x_input_extension;
-int xi_opcode;
-
 struct _xneur_config *xconfig				= NULL;
 
 /*static int get_group(Display *dpy) {

--- a/xneur/lib/main/focus.c
+++ b/xneur/lib/main/focus.c
@@ -207,7 +207,7 @@ static void grab_button(Display* display, int is_grab)
 	XIEventMask mask;
 	mask.deviceid = XIAllMasterDevices;
 	mask.mask_len = XIMaskLen(XI_RawButtonPress);
-	mask.mask = (void *)calloc(mask.mask_len, sizeof(char));
+	mask.mask = (unsigned char *)calloc(mask.mask_len, sizeof(unsigned char));
 	XISetMask(mask.mask, is_grab ? XI_RawButtonPress : 0);
 	XISelectEvents(display, DefaultRootWindow(display), &mask, 1);
 	free(mask.mask);
@@ -223,7 +223,7 @@ static void grab_all_keys(Display* display, Window window, int use_x_input_api, 
 			mask.deviceid = XIAllDevices;
 			mask.mask_len = XIMaskLen(XI_KeyPress)
 			              + XIMaskLen(XI_KeyRelease);
-			mask.mask = (void *)calloc(mask.mask_len, sizeof(char));
+			mask.mask = (unsigned char *)calloc(mask.mask_len, sizeof(unsigned char));
 			XISetMask(mask.mask, XI_KeyPress);
 			XISetMask(mask.mask, XI_KeyRelease);
 			XISelectEvents(display, DefaultRootWindow(display), &mask, 1);
@@ -238,7 +238,7 @@ static void grab_all_keys(Display* display, Window window, int use_x_input_api, 
 			XIEventMask mask;
 			mask.deviceid = XIAllMasterDevices;
 			mask.mask_len = XIMaskLen(XI_KeyPress);
-			mask.mask = (void *)calloc(mask.mask_len, sizeof(char));
+			mask.mask = (unsigned char *)calloc(mask.mask_len, sizeof(unsigned char));
 			XISetMask(mask.mask, 0);
 			XISelectEvents(display, DefaultRootWindow(display), &mask, 1);
 			free(mask.mask);

--- a/xneur/lib/main/focus.c
+++ b/xneur/lib/main/focus.c
@@ -251,18 +251,18 @@ static void grab_all_keys(Display* display, Window window, int use_x_input_api, 
 	XSelectInput(display, window, FOCUS_CHANGE_MASK);
 }
 
-static void focus_update_grab_events(struct _focus *p, int grab)
+static void focus_update_grab_events(struct _focus *p, int use_x_input_api, int grab)
 {
 	int grab_input = xconfig->tracking_input && grab;
 	int grab_mouse = xconfig->tracking_mouse && grab_input;
 
 	grab_button(main_window->display, grab_mouse);
-	grab_all_keys(main_window->display, p->owner_window, has_x_input_extension, grab_input);
+	grab_all_keys(main_window->display, p->owner_window, use_x_input_api, grab_input);
 }
 
-static void focus_click_key(struct _focus *p, int excluded, KeySym keysym)
+static void focus_click_key(struct _focus *p, int use_x_input_api, int excluded, KeySym keysym)
 {
-	focus_update_grab_events(p, FALSE);
+	focus_update_grab_events(p, use_x_input_api, FALSE);
 
 	KeyCode keycode = XKeysymToKeycode(main_window->display, keysym);
 
@@ -272,7 +272,7 @@ static void focus_click_key(struct _focus *p, int excluded, KeySym keysym)
 
 	// Enable events if they are not disabled for application
 	if (!excluded) {
-		focus_update_grab_events(p, TRUE);
+		focus_update_grab_events(p, use_x_input_api, TRUE);
 	}
 }
 

--- a/xneur/lib/main/focus.h
+++ b/xneur/lib/main/focus.h
@@ -36,8 +36,8 @@ struct _focus
 
 	int  (*get_focus_status) (struct _focus *p, int *forced_mode, int *excluded, int *autocompletion_mode);
 	int  (*is_focus_changed) (struct _focus *p);
-	void (*update_grab_events) (struct _focus *p, int grab);
-	void (*click_key) (struct _focus *p, int excluded, KeySym keysym);
+	void (*update_grab_events) (struct _focus *p, int use_x_input_api, int grab);
+	void (*click_key) (struct _focus *p, int use_x_input_api, int excluded, KeySym keysym);
 	void (*uninit) (struct _focus *p);
 };
 

--- a/xneur/lib/main/program.c
+++ b/xneur/lib/main/program.c
@@ -298,15 +298,15 @@ static void program_layout_update(struct _program *p, int layout, Window old_win
 	{
 		sprintf(window_layout, "%s %d", text_to_find, lang);
 
-		if (!xconfig->window_layouts->exist(xconfig->window_layouts, window_layout, BY_PLAIN))
+		if (!p->window_layouts->exist(p->window_layouts, window_layout, BY_PLAIN))
 			continue;
 
-		xconfig->window_layouts->rem(xconfig->window_layouts, window_layout);
+		p->window_layouts->rem(p->window_layouts, window_layout);
 	}
 
 	// Save layout for old window
 	sprintf(window_layout, "%s %d", text_to_find, layout);
-	xconfig->window_layouts->add(xconfig->window_layouts, window_layout);
+	p->window_layouts->add(p->window_layouts, window_layout);
 
 	fetch_window_name(text_to_find, new_window);
 
@@ -314,7 +314,7 @@ static void program_layout_update(struct _program *p, int layout, Window old_win
 	for (int lang = 0; lang < xconfig->handle->total_languages; lang++)
 	{
 		sprintf(window_layout, "%s %d", text_to_find, lang);
-		if (!xconfig->window_layouts->exist(xconfig->window_layouts, window_layout, BY_PLAIN))
+		if (!p->window_layouts->exist(p->window_layouts, window_layout, BY_PLAIN))
 			continue;
 
 		set_keyboard_group(lang);
@@ -3064,6 +3064,7 @@ static void program_uninit(struct _program *p)
 	p->buffer->uninit(p->buffer);
 	p->correction_buffer->uninit(p->correction_buffer);
 	p->plugin->uninit(p->plugin);
+	p->window_layouts->uninit(p->window_layouts);
 
 	main_window->uninit(main_window);
 
@@ -3108,6 +3109,7 @@ struct _program* program_init(void)
 
 	p->correction_buffer = buffer_init(xconfig->handle, main_window->keymap);
 	p->correction_action = CORRECTION_NONE;
+	p->window_layouts    = list_char_init();
 
 	// Function mapping
 	p->uninit			= program_uninit;

--- a/xneur/lib/main/program.c
+++ b/xneur/lib/main/program.c
@@ -334,7 +334,7 @@ static Window program_update(struct _program *p)
 	if (changed) {
 		p->event->set_owner_window(p->event, p->focus->owner_window);
 		// If application is excluded from tracking, disable grabbing input, otherwise enable
-		p->focus->update_grab_events(p->focus, !p->app_excluded);
+		p->focus->update_grab_events(p->focus, p->has_x_input_extension, !p->app_excluded);
 
 		program_layout_update(p, p->last_layout, prev, p->focus->owner_window);
 
@@ -531,11 +531,11 @@ static void program_process_input(struct _program *p)
 			}
 			default:
 			{
-				if (has_x_input_extension)
+				if (p->has_x_input_extension)
 				{
 					XGenericEventCookie *cookie = &p->event->event.xcookie;
 					if (cookie->type == GenericEvent &&
-						cookie->extension == xi_opcode &&
+						cookie->extension == p->xi_opcode &&
 						XGetEventData(main_window->display, cookie))
 					{
 						XIDeviceEvent* xi_event = cookie->data;
@@ -834,7 +834,7 @@ static void program_on_key_action(struct _program *p, int type, KeySym key, int 
 			 || key == XK_Num_Lock
 			 || key == XK_Scroll_Lock
 			) {
-				p->focus->click_key(p->focus, p->app_excluded, key);
+				p->focus->click_key(p->focus, p->has_x_input_extension, p->app_excluded, key);
 			}
 		}
 
@@ -3086,9 +3086,9 @@ struct _program* program_init(void)
 
 	int event = 0;
 	int error = 0;
-	has_x_input_extension = XQueryExtension(main_window->display, "XInputExtension", &xi_opcode, &event, &error);
+	p->has_x_input_extension = XQueryExtension(main_window->display, "XInputExtension", &(p->xi_opcode), &event, &error);
 
-	if (!has_x_input_extension)
+	if (!p->has_x_input_extension)
 	{
 		log_message(WARNING, _("X Input extension not available."));
 	}

--- a/xneur/lib/main/program.h
+++ b/xneur/lib/main/program.h
@@ -50,6 +50,10 @@ struct _program
 	int has_x_input_extension;
 	int xi_opcode;
 
+	/// Set with active layouts for each window
+	/// Set of pairs (Window name, active layout), data in pair delimited by space
+	struct _list_char *window_layouts;
+
 	void (*process_input) (struct _program *p);
 	void (*uninit) (struct _program *p);
 };

--- a/xneur/lib/main/program.h
+++ b/xneur/lib/main/program.h
@@ -47,6 +47,9 @@ struct _program
 
 	int last_pattern_id;
 
+	int has_x_input_extension;
+	int xi_opcode;
+
 	void (*process_input) (struct _program *p);
 	void (*uninit) (struct _program *p);
 };

--- a/xneur/lib/misc/log.c
+++ b/xneur/lib/misc/log.c
@@ -39,7 +39,7 @@ void log_message(int level, const char *string, ...)
 	if (level > LOG_LEVEL)
 		return;
 
-	char *modifier;
+	const char *modifier;
 	FILE *stream = stdout;
 	switch (level)
 	{
@@ -84,7 +84,7 @@ void log_message(int level, const char *string, ...)
 	size_t time_len = loctime != NULL
 		? strftime(time_buffer, sizeof(time_buffer)/sizeof(time_buffer[0]), "%T ", loctime)
 		: 0;
-	int len = strlen(modifier) + time_len + strlen(string) + 2;// \n + \0
+	size_t len = strlen(modifier) + time_len + strlen(string) + 2;// \n + \0
 
 	char *buffer = (char *) malloc(len + 1);
 	snprintf(buffer, len, "%s%s%s\n", modifier, time_buffer, string);
@@ -93,8 +93,11 @@ void log_message(int level, const char *string, ...)
 	va_list ap;
 	va_start(ap, string);
 
+	// TODO: Remove disabling lint when clang-tidy bug will be fixed
+	// clang-tidy bug: https://bugs.llvm.org/show_bug.cgi?id=41311
+	// NOLINTNEXTLINE(clang-analyzer-valist.Uninitialized)
 	vfprintf(stream, buffer, ap);
 
-	free(buffer);
 	va_end(ap);
+	free(buffer);
 }

--- a/xneur/lib/misc/text.h
+++ b/xneur/lib/misc/text.h
@@ -20,6 +20,8 @@
 #ifndef _TEXT_H_
 #define _TEXT_H_
 
+#include <stddef.h>
+
 int   is_upper_non_alpha_cyr(char symbol);
 //int   get_last_word_offset(const char *string, int string_len);
 //char* get_last_word(char *string);
@@ -30,7 +32,6 @@ char* str_replace(const char *source, const char *search, const char *replace);
 char* real_sym_to_escaped_sym(const char *source);
 char* escaped_sym_to_real_sym(const char *source);
 void  del_final_numeric_char(char *word);
-int levenshtein(const char *s, const char *t);
-int damerau_levenshtein(const char *string1, const char *string2, int w, int s, int a, int d);
+size_t levenshtein(const char *s, const char *t);
 
 #endif /* _TEXT_H_ */

--- a/xneur/src/newlang_creation.c
+++ b/xneur/src/newlang_creation.c
@@ -40,13 +40,12 @@ int need_skip(char ch) {
 	return isblank(ch) || iscntrl(ch) || isspace(ch) || ispunct(ch) || isdigit(ch);
 }
 void generate(struct _keymap *keymap, struct _list_char *proto2, struct _list_char *proto3, const char* text, int i, int group, int state) {
-	char buffer[256 + 1];
-
 	char *sym_i = keymap->keycode_to_symbol(keymap, i, group, state);
 	if (need_skip(sym_i[0])) {
 		free(sym_i);
 		return;
 	}
+	const size_t sym_i_len = strlen(sym_i);
 	for (int j = 0; j < 100; j++)
 	{
 		char *sym_j = keymap->keycode_to_symbol(keymap, j, group, state);
@@ -55,8 +54,11 @@ void generate(struct _keymap *keymap, struct _list_char *proto2, struct _list_ch
 			continue;
 		}
 
-		strcpy(buffer, sym_i);
-		strcat(buffer, sym_j);
+		char buffer[256 + 1];
+		const size_t BUF_SIZE = sizeof(buffer) / sizeof(buffer[0]);
+
+		strncpy(buffer, sym_i, BUF_SIZE);
+		strncat(buffer, sym_j, BUF_SIZE - sym_i_len);
 
 		if (proto2->exist(proto2, buffer, BY_PLAIN)) {
 			free(sym_j);
@@ -78,7 +80,7 @@ void generate(struct _keymap *keymap, struct _list_char *proto2, struct _list_ch
 				continue;
 			}
 
-			sprintf(buffer, "%s%s%s", sym_i, sym_j, sym_k);
+			snprintf(buffer, BUF_SIZE, "%s%s%s", sym_i, sym_j, sym_k);
 			free(sym_k);
 
 			if (proto3->exist(proto3, buffer, BY_PLAIN))


### PR DESCRIPTION
Предупреждения с неинициализированным `va_list` на самом деле являются [багом clang-tidy](https://bugs.llvm.org/show_bug.cgi?id=41311).

Также более оптимально реализовано расстояние Левенштейна, копированием алгоритма из английской Википедии. В результате:
- уменьшилось потребление памяти
- избавились от рекурсии
- решили проблему #66 (fix #66)

----

Вероятно, это последний мой PR. Программы такого типа нерационально писать на C, слишком много работы. Я занялся этим лишь для того, чтобы понять, как работает xneur и переписать его на Rust. Если в процессе дальнейшего изучения будут проясняться какие-то моменты, то может еще следую несколько PR, но в целом мне вся работа уже более-менее понятно, так что вряд ли