### PR TITLE
предложение поправить файлы tray_widget, добавить pragma deprecated

### DIFF
--- a/gxneur/src/Makefile.am
+++ b/gxneur/src/Makefile.am
@@ -10,14 +10,14 @@ gxneur_SOURCES =		\
 	callbacks.h		\
 	configuration.c		\
 	configuration.h		\
-	main.c			\
-	misc.c			\
-	misc.h			\
-	support.h		\
 	tray_widget.c		\
 	tray_widget.h		\
 	trayicon.c		\
 	trayicon.h		\
+	main.c			\
+	misc.c			\
+	misc.h			\
+	support.h		\
 	xkb.c			\
 	xkb.h
 

--- a/gxneur/src/callbacks.c
+++ b/gxneur/src/callbacks.c
@@ -17,7 +17,10 @@
  *
  */
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #include <gtk/gtk.h>
+#pragma GCC diagnostic pop
 #include <gdk/gdkx.h>
 #include <string.h>
 #include <stdlib.h>

--- a/gxneur/src/configuration.c
+++ b/gxneur/src/configuration.c
@@ -23,7 +23,10 @@
 #endif
 
 #include <gio/gio.h>
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #include <gtk/gtk.h>
+#pragma GCC diagnostic pop
 #include <gdk/gdkx.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -104,6 +107,23 @@ int gxneur_config_write_str(const char* key, const char* value)
 
 	return result;
 }
+typedef struct _callback_t
+    {
+    gxneur_config_notify_callback callback;
+    gpointer payload;
+	
+    } callback_t;
+static void gconf_callback(GConfClient* client,
+                            guint cnxn_id,
+                            GConfEntry* entry,
+                            gpointer user_data)
+    {
+    UNUSED(client || cnxn_id || entry);
+    callback_t *callback = (callback_t*)user_data;
+    g_assert(callback != NULL);
+	
+    (callback->callback)(callback->payload);
+    }
 
 int gxneur_config_add_notify(const char* key, void* callback)
 {

--- a/gxneur/src/main.c
+++ b/gxneur/src/main.c
@@ -21,7 +21,10 @@
 #   include "config.h"
 #endif
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #include <gtk/gtk.h>
+#pragma GCC diagnostic pop
 
 #include <signal.h>
 #include <stdlib.h>

--- a/gxneur/src/misc.c
+++ b/gxneur/src/misc.c
@@ -23,7 +23,10 @@
 
 #include <glib/gstdio.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #include <gtk/gtk.h>
+#pragma GCC diagnostic pop
 #include <gdk/gdkx.h>
 #include <sys/stat.h>
 #include <sys/types.h>

--- a/gxneur/src/tray_widget.c
+++ b/gxneur/src/tray_widget.c
@@ -28,8 +28,6 @@
 #pragma GCC diagnostic pop
 
 #include "tray_widget.h"
-//#include <X11/Xatom.h>
-//#include <gdk/gdkx.h>
 
 #define SYSTEM_TRAY_REQUEST_DOCK    0
 #define SYSTEM_TRAY_BEGIN_MESSAGE   1

--- a/gxneur/src/tray_widget.h
+++ b/gxneur/src/tray_widget.h
@@ -52,6 +52,7 @@ struct _GtkTrayIcon
 	GtkTrayIconPrivate *priv;
     };
 
+// перенесена из .c в header
 struct _GtkTrayIconPrivate
     {
 	guint stamp;

--- a/gxneur/src/tray_widget.h
+++ b/gxneur/src/tray_widget.h
@@ -20,7 +20,13 @@
 #ifndef __GTK_TRAY_ICON_H__
 #define __GTK_TRAY_ICON_H__
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #include <gtk/gtkplug.h>
+#pragma GCC diagnostic pop
+
+#include <X11/Xatom.h>
+#include <gdk/gdkx.h>
 
 G_BEGIN_DECLS
 
@@ -31,19 +37,44 @@ G_BEGIN_DECLS
 #define GTK_IS_TRAY_ICON_CLASS(klass)	(G_TYPE_CHECK_CLASS_TYPE ((klass), GTK_TYPE_TRAY_ICON))
 #define GTK_TRAY_ICON_GET_CLASS(obj)	(G_TYPE_INSTANCE_GET_CLASS ((obj), GTK_TYPE_TRAY_ICON, GtkTrayIconClass))
 
+// https://sigquit.wordpress.com/2009/02/13/avoid-g_type_instance_get_private-in-gobjects/
+#define GTK_TRAY_ICON_GET_PRIVATE(obj) ((GtkTrayIconPrivate *)((GTK_TRAY_ICON(obj))->priv))
+
 typedef struct _GtkTrayIcon	   GtkTrayIcon;
 typedef struct _GtkTrayIconPrivate GtkTrayIconPrivate;
 typedef struct _GtkTrayIconClass   GtkTrayIconClass;
 
 struct _GtkTrayIcon
-{
+    {
+    /** Parent object */
 	GtkPlug parent_instance;
-
+    /** Private data pointer */
 	GtkTrayIconPrivate *priv;
-};
+    };
+
+struct _GtkTrayIconPrivate
+    {
+	guint stamp;
+
+	Atom selection_atom;
+	Atom manager_atom;
+	Atom system_tray_opcode_atom;
+	Atom orientation_atom;
+	Atom visual_atom;
+	Window manager_window;
+	GdkVisual *manager_visual;
+	gboolean manager_visual_rgba;
+
+	GtkOrientation orientation;
+
+    /** Parent object */
+	GObject parent_instance;
+    /** Private data pointer */
+	gpointer priv;
+    };
 
 struct _GtkTrayIconClass
-{
+    {
 	GtkPlugClass parent_class;
 
 	void (*__gtk_reserved1);
@@ -52,21 +83,16 @@ struct _GtkTrayIconClass
 	void (*__gtk_reserved4);
 	void (*__gtk_reserved5);
 	void (*__gtk_reserved6);
-};
+    };
 
-GType          gtk_tray_icon_get_type         (void) G_GNUC_CONST;
+GType gtk_tray_icon_get_type (void) G_GNUC_CONST;
 
-GtkTrayIcon   *_gtk_tray_icon_new_for_screen  (GdkScreen   *screen,
-					       const gchar *name);
+GtkTrayIcon* _gtk_tray_icon_new_for_screen(GdkScreen *screen, const gchar *name);
 
-GtkTrayIcon   *_gtk_tray_icon_new             (const gchar *name);
+GtkTrayIcon* _gtk_tray_icon_new(const gchar *name);
 
-guint          _gtk_tray_icon_send_message    (GtkTrayIcon *icon,
-					       gint         timeout,
-					       const gchar *message,
-					       gint         len);
-void           _gtk_tray_icon_cancel_message  (GtkTrayIcon *icon,
-					       guint        id);
+guint _gtk_tray_icon_send_message(GtkTrayIcon *icon, gint timeout, const gchar *message, gint len);
+void _gtk_tray_icon_cancel_message(GtkTrayIcon *icon, guint id);
 
 GtkOrientation _gtk_tray_icon_get_orientation (GtkTrayIcon *icon);
 

--- a/gxneur/src/trayicon.c
+++ b/gxneur/src/trayicon.c
@@ -21,7 +21,10 @@
 #   include "config.h"
 #endif
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #include <gtk/gtk.h>
+#pragma GCC diagnostic pop
 
 #include <stdlib.h>
 #include <ctype.h>
@@ -710,3 +713,4 @@ void create_tray_icon (void)
 
 	g_timeout_add(1000, clock_check, 0);
 }
+


### PR DESCRIPTION
Linux Mint 20.1 (x64)
компилировал xneur и gxneur 0.19.0 практически с лету
gxneur 0.20.0 не ставится ни в какую - warnings типа deprecated воспринимаются как ошибки
и если эту проблемку можно приглушить с помощью #pragma. то строка

static void gtk_tray_icon_init(GtkTrayIcon *icon)
{
icon->priv = G_TYPE_INSTANCE_GET_PRIVATE (icon, GTK_TYPE_TRAY_ICON, GtkTrayIconPrivate); 

Выдает ошибку deprecated pre-processor symbol, указывая на TrayIconPrivate);

Решил эту проблему, прочитав статью https://sigquit.wordpress.com/2009/02/13/avoid-g_type_instance_get_private-in-gobjects/
